### PR TITLE
Add default value for migration

### DIFF
--- a/holobot/extensions/reminders/database/reminder_migration.py
+++ b/holobot/extensions/reminders/database/reminder_migration.py
@@ -16,7 +16,7 @@ class ReminderMigration(MigrationBase):
     async def __upgrade_to_v2(self, connection: Connection) -> None:
         await connection.execute((
             "ALTER TABLE reminders"
-            " ADD COLUMN base_trigger TIMESTAMP NOT NULL"
+            " ADD COLUMN base_trigger TIMESTAMP NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc')"
         ))
 
     async def __initialize_table(self, connection: Connection) -> None:


### PR DESCRIPTION
As no default value was specified, the database migration failed due to already existing records violating the "not null" constraint.