### PR TITLE
Display the name of the artist who created the bot's avatar

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,8 @@
             "IsDebug": false,
             "DiscordToken": "",
             "LogLevel": "Information",
-            "HttpPoolSize": 50
+            "HttpPoolSize": 50,
+            "AvatarArtworkArtistName": "unknown"
         }
     },
     "Google": {

--- a/holobot/discord/data_providers/bot_data_provider.py
+++ b/holobot/discord/data_providers/bot_data_provider.py
@@ -4,8 +4,13 @@ from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IBotDataProvider)
 class BotDataProvider(IBotDataProvider):
+    def get_user_id(self) -> str:
+        user = BotAccessor.get_bot().user
+        return str(user.id) if user else ""
+
     def get_avatar_url(self) -> str:
-        return str(BotAccessor.get_bot().user.avatar_url)
+        user = BotAccessor.get_bot().user
+        return str(user.avatar_url) if user else ""
 
     def get_latency(self) -> float:
         return BotAccessor.get_bot().latency * 1000

--- a/holobot/discord/sdk/data_providers/ibot_data_provider.py
+++ b/holobot/discord/sdk/data_providers/ibot_data_provider.py
@@ -1,4 +1,7 @@
 class IBotDataProvider:
+    def get_user_id(self) -> str:
+        raise NotImplementedError
+
     def get_avatar_url(self) -> str:
         raise NotImplementedError
 


### PR DESCRIPTION
When a user uses `/avatar` for the bot's profile picture, a footer is added to display the configurable name of the artist who drew the artwork.