### PR TITLE
Implement an I18N provider

### DIFF
--- a/holobot/discord/actions/action_processor.py
+++ b/holobot/discord/actions/action_processor.py
@@ -61,7 +61,8 @@ class ActionProcessor(IActionProcessor):
                     content=content,
                     embed=embed or UNDEFINED,
                     components=components,
-                    flags=MessageFlag.EPHEMERAL if is_ephemeral else MessageFlag.NONE
+                    flags=MessageFlag.EPHEMERAL if is_ephemeral else MessageFlag.NONE,
+                    user_mentions=not action.suppress_user_mentions or UNDEFINED
                 )
                 return
 
@@ -69,7 +70,8 @@ class ActionProcessor(IActionProcessor):
                 await interaction.edit_initial_response(
                     content=content,
                     embed=embed,
-                    components=components
+                    components=components,
+                    user_mentions=not action.suppress_user_mentions or UNDEFINED
                 )
                 return
 
@@ -95,7 +97,8 @@ class ActionProcessor(IActionProcessor):
                     content=content,
                     embed=embed or UNDEFINED,
                     components=components,
-                    flags=MessageFlag.EPHEMERAL if is_ephemeral else MessageFlag.NONE
+                    flags=MessageFlag.EPHEMERAL if is_ephemeral else MessageFlag.NONE,
+                    user_mentions=not action.suppress_user_mentions or UNDEFINED
                 )
                 return
 
@@ -103,7 +106,8 @@ class ActionProcessor(IActionProcessor):
                 await interaction.edit_initial_response(
                     content=content,
                     embed=embed,
-                    components=components
+                    components=components,
+                    user_mentions=not action.suppress_user_mentions or UNDEFINED
                 )
                 return
 

--- a/holobot/discord/sdk/actions/action_base.py
+++ b/holobot/discord/sdk/actions/action_base.py
@@ -1,2 +1,8 @@
+from dataclasses import dataclass
+
+@dataclass(kw_only=True, frozen=True)
 class ActionBase:
     """Abstract base class for actions."""
+
+    suppress_user_mentions: bool = False
+    """Determines whether user mentions should avoid sending a notification."""

--- a/holobot/discord/sdk/actions/content_changing_action_base.py
+++ b/holobot/discord/sdk/actions/content_changing_action_base.py
@@ -5,7 +5,7 @@ from .action_base import ActionBase
 from ..models import Embed
 from holobot.discord.sdk.workflows.interactables.components import ComponentBase, Layout
 
-@dataclass
+@dataclass(kw_only=True, frozen=True)
 class ContentChangingActionBase(ActionBase):
     content: Union[str, Embed]
     components: Union[ComponentBase, List[Layout]] = field(default_factory=lambda: [])

--- a/holobot/discord/sdk/actions/edit_message_action.py
+++ b/holobot/discord/sdk/actions/edit_message_action.py
@@ -2,6 +2,6 @@ from dataclasses import dataclass
 
 from .content_changing_action_base import ContentChangingActionBase
 
-@dataclass
+@dataclass(kw_only=True, frozen=True)
 class EditMessageAction(ContentChangingActionBase):
     """An action that edits the interaction's message."""

--- a/holobot/discord/sdk/actions/reply_action.py
+++ b/holobot/discord/sdk/actions/reply_action.py
@@ -2,6 +2,6 @@ from dataclasses import dataclass
 
 from .content_changing_action_base import ContentChangingActionBase
 
-@dataclass
+@dataclass(kw_only=True, frozen=True)
 class ReplyAction(ContentChangingActionBase):
     """An action that replies to a request with a message."""

--- a/holobot/discord/sdk/servers/models/member_data.py
+++ b/holobot/discord/sdk/servers/models/member_data.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
-from typing import Optional
 
 @dataclass
 class MemberData:
     user_id: str
-    avatar_url: Optional[str]
+    avatar_url: str | None
     name: str
-    nick_name: Optional[str]
+    nick_name: str | None
+    is_self: bool
+    is_bot: bool
 
     @property
     def display_name(self) -> str:

--- a/holobot/discord/sdk/workflows/interactables/decorators/command.py
+++ b/holobot/discord/sdk/workflows/interactables/decorators/command.py
@@ -57,7 +57,7 @@ def command(
             is_ephemeral=is_ephemeral,
             required_permissions=required_permissions,
             defer_type=defer_type,
-            server_ids=server_ids if server_ids else set()
+            server_ids=server_ids or set()
         ))
         return target
     return wrapper

--- a/holobot/discord/sdk/workflows/iworkflow.py
+++ b/holobot/discord/sdk/workflows/iworkflow.py
@@ -1,21 +1,19 @@
-from abc import ABCMeta, abstractmethod
-from typing import Tuple
+from typing import Protocol
 
 from .interactables import Interactable
 from ..enums import Permission
 
-class IWorkflow(metaclass=ABCMeta):
+class IWorkflow(Protocol):
     @property
-    @abstractmethod
     def name(self) -> str:
         """Gets the name of the workflow which is also its unique identifier.
 
         :return: The name of the workflow.
         :rtype: str
         """
+        ...
 
     @property
-    @abstractmethod
     def required_permissions(self) -> Permission:
         """Gets an enumeration of the permissions required to invoke interactables of the workflow.
 
@@ -26,12 +24,13 @@ class IWorkflow(metaclass=ABCMeta):
         :return: The permissions required by the workflow's interactables.
         :rtype: Permission
         """
+        ...
 
     @property
-    @abstractmethod
-    def interactables(self) -> Tuple[Interactable, ...]:
+    def interactables(self) -> tuple[Interactable, ...]:
         """Gets the list of interactable registrations associated to the workflow.
 
         :return: The associated interactable registrations.
-        :rtype: Tuple[InteractableRegistration, ...]
+        :rtype: tuple[InteractableRegistration, ...]
         """
+        ...

--- a/holobot/discord/sdk/workflows/workflow_base.py
+++ b/holobot/discord/sdk/workflows/workflow_base.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Protocol
 
 from .constants import WORKFLOW_PREDEFINED_INTERACTABLES
 from .interactables import Interactable
@@ -6,7 +6,10 @@ from .iworkflow import IWorkflow
 from .workflow_meta import WorkflowMeta
 from ..enums import Permission
 
-class WorkflowBase(IWorkflow, metaclass=WorkflowMeta):
+class MixinMeta(WorkflowMeta, type(Protocol)):
+    pass
+
+class WorkflowBase(IWorkflow, metaclass=MixinMeta):
     @property
     def name(self) -> str:
         return self.__name
@@ -16,24 +19,24 @@ class WorkflowBase(IWorkflow, metaclass=WorkflowMeta):
         return self.__required_permissions
 
     @property
-    def interactables(self) -> Tuple[Interactable, ...]:
+    def interactables(self) -> tuple[Interactable, ...]:
         return tuple(self.__interactables)
 
     def __init__(
         self,
         *,
-        name: Optional[str] = None,
-        interactables: Tuple[Interactable, ...] = (),
+        name: str | None = None,
+        interactables: tuple[Interactable, ...] = (),
         required_permissions: Permission = Permission.NONE
     ) -> None:
         self.__name: str = name or type(self).__name__
         self.__required_permissions: Permission = required_permissions
-        predefined_interactables: List[Interactable] = getattr(
+        predefined_interactables: list[Interactable] = getattr(
             self,
             WORKFLOW_PREDEFINED_INTERACTABLES,
             []
         )
-        self.__interactables: List[Interactable] = list(predefined_interactables)
+        self.__interactables: list[Interactable] = list(predefined_interactables)
         self.__interactables.extend(interactables)
 
     def add_registration(self, registration: Interactable) -> None:

--- a/holobot/discord/servers/member_data_provider.py
+++ b/holobot/discord/servers/member_data_provider.py
@@ -1,5 +1,10 @@
+from typing import List, Mapping, Tuple
+
+import hikari
+
 from ..utils import get_guild_member
 from ..utils.permission_utils import PERMISSION_TO_MODELS
+from holobot.discord.bot import BotAccessor
 from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.exceptions import UserNotFoundError
 from holobot.discord.sdk.servers import IMemberDataProvider
@@ -7,9 +12,6 @@ from holobot.discord.sdk.servers.models import MemberData
 from holobot.discord.utils import get_guild_channel, get_guild
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.utils import assert_not_none, first_or_default
-from typing import List, Mapping, Tuple
-
-import hikari
 
 @injectable(IMemberDataProvider)
 class MemberDataProvider(IMemberDataProvider):
@@ -93,11 +95,14 @@ class MemberDataProvider(IMemberDataProvider):
 
     @staticmethod
     def __member_to_basic_data(user: hikari.Member) -> MemberData:
+        bot_user = BotAccessor.get_bot().get_me()
         return MemberData(
             user_id=str(user.id),
             avatar_url=user.avatar_url.url if user.avatar_url else None,
             name=user.username,
-            nick_name=user.nickname
+            nick_name=user.nickname,
+            is_self=bot_user.id == user.id if bot_user else False,
+            is_bot=user.is_bot
         )
 
     @staticmethod

--- a/holobot/discord/workflows/interaction_processor_base.py
+++ b/holobot/discord/workflows/interaction_processor_base.py
@@ -15,6 +15,7 @@ from holobot.discord.sdk.workflows.interactables import Interactable
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.rules import IWorkflowExecutionRule
 from holobot.sdk.diagnostics import IExecutionContext, IExecutionContextFactory
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.logging import ILoggerFactory
 
 TInteractable = TypeVar("TInteractable", bound=Interactable, contravariant=True)
@@ -29,12 +30,14 @@ class InteractionProcessorBase(
     def __init__(
         self,
         action_processor: IActionProcessor,
+        i18n_provider: II18nProvider,
         logger_factory: ILoggerFactory,
         execution_context_factory: IExecutionContextFactory,
         workflow_execution_rules: Tuple[IWorkflowExecutionRule, ...]
     ) -> None:
         super().__init__()
         self.__action_processor = action_processor
+        self.__i18n_provider = i18n_provider
         self.__log = logger_factory.create(type(self))
         self.__execution_context_factory = execution_context_factory
         self.__workflow_execution_rules = workflow_execution_rules
@@ -152,7 +155,7 @@ class InteractionProcessorBase(
 
         await self.__action_processor.process(
             interaction,
-            ReplyAction(content="I couldn't execute your command, because it's invalid."),
+            ReplyAction(content=self.__i18n_provider.get("interactions.invalid_interaction_error")),
             DeferType.NONE,
             True
         )
@@ -177,7 +180,7 @@ class InteractionProcessorBase(
         await self.__action_processor.process(
             interaction,
             ReplyAction(
-                content="You're not allowed to interact with that message."
+                content=self.__i18n_provider.get("interactions.unbound_interaction_user_error")
             ),
             DeferType.NONE,
             True
@@ -202,7 +205,7 @@ class InteractionProcessorBase(
                 await self.__action_processor.process(
                     interaction,
                     ReplyAction(
-                        content="You're not allowed to use this command."
+                        content=self.__i18n_provider.get("interactions.halted_interaction_error")
                     ),
                     DeferType.NONE,
                     True

--- a/holobot/discord/workflows/processors/command_processor.py
+++ b/holobot/discord/workflows/processors/command_processor.py
@@ -14,6 +14,7 @@ from holobot.discord.workflows import IInteractionProcessor, InteractionProcesso
 from holobot.discord.workflows.models import InteractionDescriptor
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.diagnostics import IExecutionContextFactory
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.logging import ILoggerFactory
 from holobot.sdk.reactive import IListener
 
@@ -23,12 +24,13 @@ class CommandProcessor(InteractionProcessorBase[CommandInteraction, Command]):
         self,
         action_processor: IActionProcessor,
         event_listeners: Tuple[IListener[CommandProcessedEvent], ...],
+        i18n_provider: II18nProvider,
         log: ILoggerFactory,
         measurement_context_factory: IExecutionContextFactory,
         workflow_execution_rules: Tuple[IWorkflowExecutionRule, ...],
         workflow_registry: IWorkflowRegistry
     ) -> None:
-        super().__init__(action_processor, log, measurement_context_factory, workflow_execution_rules)
+        super().__init__(action_processor, i18n_provider, log, measurement_context_factory, workflow_execution_rules)
         self.__event_listeners = sorted(event_listeners, key=lambda i: i.priority)
         self.__workflow_registry = workflow_registry
 

--- a/holobot/discord/workflows/processors/component_processor.py
+++ b/holobot/discord/workflows/processors/component_processor.py
@@ -15,6 +15,7 @@ from holobot.discord.workflows.models import InteractionDescriptor
 from holobot.discord.workflows.transformers import IComponentTransformer
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.diagnostics import IExecutionContextFactory
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.logging import ILoggerFactory
 from holobot.sdk.reactive import IListener
 
@@ -25,12 +26,13 @@ class ComponentProcessor(InteractionProcessorBase[ComponentInteraction, Componen
         action_processor: IActionProcessor,
         component_transformer: IComponentTransformer,
         event_listeners: Tuple[IListener[ComponentProcessedEvent], ...],
+        i18n_provider: II18nProvider,
         log: ILoggerFactory,
         measurement_context_factory: IExecutionContextFactory,
         workflow_execution_rules: Tuple[IWorkflowExecutionRule, ...],
         workflow_registry: IWorkflowRegistry
     ) -> None:
-        super().__init__(action_processor, log, measurement_context_factory, workflow_execution_rules)
+        super().__init__(action_processor, i18n_provider, log, measurement_context_factory, workflow_execution_rules)
         self.__component_transformer = component_transformer
         self.__event_listeners = sorted(event_listeners, key=lambda i: i.priority)
         self.__workflow_registry = workflow_registry

--- a/holobot/discord/workflows/processors/menu_item_processor.py
+++ b/holobot/discord/workflows/processors/menu_item_processor.py
@@ -16,6 +16,7 @@ from holobot.discord.workflows import InteractionProcessorBase, IWorkflowRegistr
 from holobot.discord.workflows.models import InteractionDescriptor
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.diagnostics import IExecutionContextFactory
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.logging import ILoggerFactory
 from holobot.sdk.reactive import IListener
 
@@ -25,12 +26,13 @@ class MenuItemProcessor(InteractionProcessorBase[CommandInteraction, MenuItem], 
         self,
         action_processor: IActionProcessor,
         event_listeners: Tuple[IListener[MenuItemProcessedEvent], ...],
+        i18n_provider: II18nProvider,
         log: ILoggerFactory,
         measurement_context_factory: IExecutionContextFactory,
         workflow_execution_rules: Tuple[IWorkflowExecutionRule, ...],
         workflow_registry: IWorkflowRegistry
     ) -> None:
-        super().__init__(action_processor, log, measurement_context_factory, workflow_execution_rules)
+        super().__init__(action_processor, i18n_provider, log, measurement_context_factory, workflow_execution_rules)
         self.__event_listeners = sorted(event_listeners, key=lambda i: i.priority)
         self.__workflow_registry = workflow_registry
 

--- a/holobot/extensions/admin/workflows/help_workflow.py
+++ b/holobot/extensions/admin/workflows/help_workflow.py
@@ -4,12 +4,17 @@ from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class HelpWorkflow(WorkflowBase):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider
+    ) -> None:
         super().__init__(required_permissions=Permission.ADMINISTRATOR)
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="A brief explanation of how the rules are applied to the commands.",
@@ -22,17 +27,7 @@ class HelpWorkflow(WorkflowBase):
         context: ServerChatInteractionContext
     ) -> InteractionResponse:
         return InteractionResponse(
-            action=ReplyAction(content=(
-                "Rules are logically separated by the following types:\n"
-                "- **Global rules**: These rules apply to every command, regardless of group, sub-group or name.\n"
-                "- **Group rules**: These rules apply to entire command groups, such as \"admin\".\n"
-                "- **Sub-group rules**: These rules apply to a specific sub-group of a specific group, such as \"commands\".\n"
-                "- **Command rules**: These rules apply to specific commands, such as \"help\".\n"
-                "Each one of these groups may apply to all channels or a specific channel only.\n\n"
-                "The rule precedence is as follows: _global rules > group rules > sub-group rules > command rules_."
-                " Rules that apply to all channels are applied before those that apply to specific channels only.\n\n"
-                "For example, to allow the execution of commands in a single channel only, you would need two rules:\n"
-                "1. :no_entry: Forbid the execution of all commands in every channel.\n"
-                "2. :white_check_mark: Allow the execution of all commands in a specific channel."
+            action=ReplyAction(content=self.__i18n_provider.get(
+                "extensions.admin.help_workflow.explanation"
             ))
         )

--- a/holobot/extensions/admin/workflows/remove_all_command_rules_workflow.py
+++ b/holobot/extensions/admin/workflows/remove_all_command_rules_workflow.py
@@ -5,13 +5,19 @@ from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class RemoveAllCommandRulesWorkflow(WorkflowBase):
-    def __init__(self, rule_manager: CommandRuleManagerInterface) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        rule_manager: CommandRuleManagerInterface
+    ) -> None:
         super().__init__(required_permissions=Permission.ADMINISTRATOR)
         self.__command_rule_manager: CommandRuleManagerInterface = rule_manager
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="Removes ALL command rules specified for this server.",
@@ -25,10 +31,14 @@ class RemoveAllCommandRulesWorkflow(WorkflowBase):
     async def execute(self, context: ServerChatInteractionContext, confirmation: str) -> InteractionResponse:
         if confirmation != "confirm":
             return InteractionResponse(
-                action=ReplyAction(content="No rules have been removed. You must confirm your intention correctly.")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.admin.remove_all_command_rules_workflow.no_rules_removed"
+                ))
             )
 
         await self.__command_rule_manager.remove_rules_by_server(context.server_id)
         return InteractionResponse(
-            action=ReplyAction(content="ALL rules specified for this server have been removed.")
+            action=ReplyAction(content=self.__i18n_provider.get(
+                "extensions.admin.remove_all_command_rules_workflow.all_rules_removed"
+            ))
         )

--- a/holobot/extensions/admin/workflows/remove_command_rule_workflow.py
+++ b/holobot/extensions/admin/workflows/remove_command_rule_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class RemoveCommandRuleWorkflow(WorkflowBase):
-    def __init__(self, rule_manager: CommandRuleManagerInterface) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        rule_manager: CommandRuleManagerInterface
+    ) -> None:
         super().__init__(required_permissions=Permission.ADMINISTRATOR)
         self.__command_rule_manager: CommandRuleManagerInterface = rule_manager
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="Removes the specified rule.",
@@ -30,5 +36,7 @@ class RemoveCommandRuleWorkflow(WorkflowBase):
     ) -> InteractionResponse:
         await self.__command_rule_manager.remove_rule(identifier)
         return InteractionResponse(
-            action=ReplyAction(content="The rule has been removed.")
+            action=ReplyAction(content=self.__i18n_provider.get(
+                "extensions.admin.remove_command_rule_workflow.rule_removed"
+            ))
         )

--- a/holobot/extensions/admin/workflows/test_command_workflow.py
+++ b/holobot/extensions/admin/workflows/test_command_workflow.py
@@ -1,4 +1,5 @@
-from .. import CommandRegistryInterface, CommandRuleManagerInterface
+from typing import Optional
+
 from holobot.discord.sdk.actions import ReplyAction
 from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.utils import get_channel_id_or_default
@@ -6,19 +7,22 @@ from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.extensions.admin import CommandRegistryInterface, CommandRuleManagerInterface
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
-from typing import Optional
 
 @injectable(IWorkflow)
 class TestCommandWorkflow(WorkflowBase):
     def __init__(
         self,
         command_registry: CommandRegistryInterface,
+        i18n_provider: II18nProvider,
         rule_manager: CommandRuleManagerInterface
     ) -> None:
         super().__init__(required_permissions=Permission.ADMINISTRATOR)
         self.__command_registry: CommandRegistryInterface = command_registry
         self.__command_rule_manager: CommandRuleManagerInterface = rule_manager
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="Checks if a command can be used in the current or the specified channel.",
@@ -42,17 +46,28 @@ class TestCommandWorkflow(WorkflowBase):
     ) -> InteractionResponse:
         if context.server_id is None:
             return InteractionResponse(
-                action=ReplyAction(content="Command rules can be defined in servers only.")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "interactions.server_only_interaction_error"
+                ))
             )
 
         if not self.__command_registry.command_exists(command, group, subgroup):
             return InteractionResponse(
-                action=ReplyAction(content="The command you specified doesn't exist. Did you make a typo?")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.admin.test_command_workflow.invalid_command_error"
+                ))
             )
 
         channel_id = get_channel_id_or_default(channel, context.channel_id) if channel is not None else context.channel_id
         can_execute = await self.__command_rule_manager.can_execute(context.server_id, channel_id, group, subgroup, command)
-        disabled_text = "" if can_execute else " NOT"
+        i18n_key = (
+            "extensions.admin.test_command_workflow.command_can_execute"
+            if can_execute
+            else "extensions.admin.test_command_workflow.command_cannot_execute"
+        )
         return InteractionResponse(
-            action=ReplyAction(content=f"The command CAN{disabled_text} be executed in <#{channel_id}>.")
+            action=ReplyAction(content=self.__i18n_provider.get(
+                i18n_key,
+                { "channel_id": channel_id }
+            ))
         )

--- a/holobot/extensions/crypto/workflows/view_alarms_workflow.py
+++ b/holobot/extensions/crypto/workflows/view_alarms_workflow.py
@@ -34,8 +34,14 @@ class ViewAlarmsWorkflow(WorkflowBase):
         subgroup_name="alarm"
     )
     async def view_alarms(self, context: ServerChatInteractionContext) -> InteractionResponse:
+        content, components = await self.__create_page_content(
+            context.author_id,
+            0,
+            DEFAULT_PAGE_SIZE
+        )
         return InteractionResponse(ReplyAction(
-            *await self.__create_page_content(context.author_id, 0, DEFAULT_PAGE_SIZE)
+            content=content,
+            components=components
         ))
 
     @component(
@@ -49,16 +55,18 @@ class ViewAlarmsWorkflow(WorkflowBase):
         context: InteractionContext,
         state: Any
     ) -> InteractionResponse:
+        content, components = await self.__create_page_content(
+            state.owner_id,
+            max(state.current_page, 0),
+            DEFAULT_PAGE_SIZE
+        )
         return InteractionResponse(
             EditMessageAction(
-                *await self.__create_page_content(
-                    state.owner_id,
-                    max(state.current_page, 0),
-                    DEFAULT_PAGE_SIZE
-                )
+                content=content,
+                components=components
             )
             if isinstance(state, PagerState)
-            else EditMessageAction("An internal error occurred while processing the interaction.")
+            else EditMessageAction(content="An internal error occurred while processing the interaction.")
         )
 
     async def __create_page_content(

--- a/holobot/extensions/dev/workflows/show_available_servers_workflow.py
+++ b/holobot/extensions/dev/workflows/show_available_servers_workflow.py
@@ -56,19 +56,21 @@ class ShowAvailableServersWorkflow(WorkflowBase):
         state: Any
     ) -> InteractionResponse:
         if not isinstance(context, ServerChatInteractionContext):
-            return InteractionResponse(EditMessageAction("This interaction is available in a server only."))
+            return InteractionResponse(EditMessageAction(content="This interaction is available in a server only."))
 
+        content, components = await self.__create_page_content(
+            max(state.current_page, 0),
+            PAGE_SIZE,
+            0,
+            state.owner_id
+        )
         return InteractionResponse(
             EditMessageAction(
-                *await self.__create_page_content(
-                    max(state.current_page, 0),
-                    PAGE_SIZE,
-                    0,
-                    state.owner_id
-                )
+                content=content,
+                components=components
             )
             if isinstance(state, PagerState)
-            else EditMessageAction("This interaction isn't valid anymore.")
+            else EditMessageAction(content="This interaction isn't valid anymore.")
         )
 
     @component(
@@ -81,20 +83,22 @@ class ShowAvailableServersWorkflow(WorkflowBase):
         state: Any
     ) -> InteractionResponse:
         if not isinstance(context, ServerChatInteractionContext):
-            return InteractionResponse(EditMessageAction("This interaction is available in a server only."))
+            return InteractionResponse(EditMessageAction(content="This interaction is available in a server only."))
 
         if not isinstance(state, ComboBoxState):
-            return InteractionResponse(EditMessageAction("This interaction isn't valid anymore."))
+            return InteractionResponse(EditMessageAction(content="This interaction isn't valid anymore."))
 
         page_index, server_index = state.selected_values[0].split(";")
+        content, components = await self.__create_page_content(
+            max(int(page_index), 0),
+            PAGE_SIZE,
+            int(server_index),
+            state.owner_id
+        )
         return InteractionResponse(
             EditMessageAction(
-                *await self.__create_page_content(
-                    max(int(page_index), 0),
-                    PAGE_SIZE,
-                    int(server_index),
-                    state.owner_id
-                )
+                content=content,
+                components=components
             )
         )
 

--- a/holobot/extensions/general/workflows/magic_eight_ball_workflow.py
+++ b/holobot/extensions/general/workflows/magic_eight_ball_workflow.py
@@ -1,40 +1,32 @@
 from random import Random
-from typing import Tuple
 
 from holobot.discord.sdk.actions import ReplyAction
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
+from holobot.sdk.lifecycle import IStartable
 
+@injectable(IStartable)
 @injectable(IWorkflow)
-class MagicEightBallWorkflow(WorkflowBase):
-    def __init__(self) -> None:
+class MagicEightBallWorkflow(WorkflowBase, IStartable):
+    def __init__(
+        self,
+        i18n_provider: II18nProvider
+    ) -> None:
         super().__init__()
-        self.__answers: Tuple[str, ...] = (
-            # Positive answers.
-            "Yes.",
-            "But of course!",
-            "Certainly.",
-            "Without a doubt.",
-            "Yes, definitely.",
-            "Most likely.",
-            "It seems to be the case.",
+        self.__i18n_provider = i18n_provider
+        self.__answers: tuple[str, ...] =  ()
 
-            # Negative answers.
-            "No.",
-            "Of course, not!",
-            "Quite unlikely.",
-            "Don't count on it.",
-            "I don't think so.",
-
-            # Neutral answers.
-            "Maybe.",
-            "You don't have to know that.",
-            "That's not your cup of tea.",
-            "Who knows..."
+    async def start(self):
+        self.__answers = self.__i18n_provider.get_list(
+            "extensions.general.magic_eight_ball_workflow.responses"
         )
+
+    async def stop(self):
+        pass
 
     @command(
         description="Answers your yes/no question.",

--- a/holobot/extensions/general/workflows/roll_number_workflow.py
+++ b/holobot/extensions/general/workflows/roll_number_workflow.py
@@ -6,12 +6,19 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
+
+_NAMED_DICE = {1, 4, 6, 8, 10, 12, 20, 24, 50, 120}
 
 @injectable(IWorkflow)
 class RollNumberWorkflow(WorkflowBase):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider
+    ) -> None:
         super().__init__()
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="Generates a random integer between the specified bounds.",
@@ -30,6 +37,21 @@ class RollNumberWorkflow(WorkflowBase):
         if max < min:
             (min, max) = (max, min)
 
+        result = randint(min, max)
+        die_name = ""
+        message_key = "extensions.general.roll_number_workflow.unusual_roll_result"
+        if min == 1 and max in _NAMED_DICE:
+            die_name = self.__i18n_provider.get(
+                f"extensions.general.roll_number_workflow.die_{max}"
+            )
+            message_key = "extensions.general.roll_number_workflow.usual_roll_result"
+
         return InteractionResponse(
-            action=ReplyAction(content=f"You rolled {randint(min, max)}.")
+            action=ReplyAction(content=self.__i18n_provider.get(
+                message_key,
+                {
+                    "name": die_name,
+                    "value": result
+                }
+            ))
         )

--- a/holobot/extensions/general/workflows/summon_user_workflow.py
+++ b/holobot/extensions/general/workflows/summon_user_workflow.py
@@ -13,6 +13,7 @@ from holobot.discord.sdk.exceptions import (
 from holobot.discord.sdk.servers import IMemberDataProvider
 from holobot.discord.sdk.utils import get_user_id
 from holobot.discord.sdk.utils.mention_utils import get_channel_id_or_default
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 MESSAGE_LENGTH_MAX = 192
@@ -21,12 +22,14 @@ MESSAGE_LENGTH_MAX = 192
 class SummonUserWorkflow(WorkflowBase):
     def __init__(
         self,
+        i18n_provider: II18nProvider,
         member_data_provider: IMemberDataProvider,
         messaging: IMessaging
     ) -> None:
         super().__init__()
-        self.__member_data_provider: IMemberDataProvider = member_data_provider
-        self.__messaging: IMessaging = messaging
+        self.__i18n_provider = i18n_provider
+        self.__member_data_provider = member_data_provider
+        self.__messaging = messaging
 
     @command(
         description="Requests a user's presence via a direct message.",
@@ -45,35 +48,80 @@ class SummonUserWorkflow(WorkflowBase):
         channel: Optional[str] = None
     ) -> InteractionResponse:
         if not name:
-            return InteractionResponse(
-                action=ReplyAction(content="You must specify a user by their name or mention.")
-            )
-        
+            return InteractionResponse(ReplyAction(content=self.__i18n_provider.get(
+                "missing_required_argument_error", { "argname": "name" }
+            )))
+
         try:
             name = name.strip()
             user_id = get_user_id(name)
-            if not user_id:
-                member = self.__member_data_provider.get_basic_data_by_name(context.server_id, name)
-                if not member:
-                    return InteractionResponse(action=ReplyAction(content="I can't find the user you specified. Did you make a typo?"))
-                user_id = member.user_id
+            member = (
+                self.__member_data_provider.get_basic_data_by_id(context.server_id, user_id)
+                if user_id
+                else self.__member_data_provider.get_basic_data_by_name(context.server_id, name)
+            )
+            if not member:
+                return InteractionResponse(action=ReplyAction(
+                    content=self.__i18n_provider.get("user_not_found_error")
+                ))
+            if member.is_self:
+                return InteractionResponse(action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.general.summon_user_workflow.cannot_summon_self_error"
+                    )
+                ))
+            if member.is_bot:
+                return InteractionResponse(action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.general.summon_user_workflow.cannot_summon_bot_error"
+                    )
+                ))
+
+            user_id = member.user_id
             if user_id == context.author_id:
-                return InteractionResponse(action=ReplyAction(content="You can't summon yourself, silly."))
-            
+                return InteractionResponse(ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.general.summon_user_workflow.self_summon",
+                    { "user_id": context.author_id }
+                )))
+
             channel_id = get_channel_id_or_default(channel, context.channel_id) if channel else context.channel_id
+            dm_message_key = "extensions.general.summon_user_workflow.dm_summon"
             if message:
                 message = message.strip()[:MESSAGE_LENGTH_MAX]
-                target_message = "{} is summoning you to <#{}> with the message '{}'."
-            else: target_message = "{} is summoning you to <#{}>."
+                dm_message_key = "extensions.general.summon_user_workflow.dm_summon_with_message"
 
-            await self.__messaging.send_private_message(user_id, target_message.format(context.author_nickname or context.author_name, channel_id, message))
+            await self.__messaging.send_private_message(
+                user_id,
+                self.__i18n_provider.get(
+                    dm_message_key,
+                    {
+                        "user_name": context.author_nickname or context.author_name,
+                        "channel_id": channel_id,
+                        "message": message
+                    }
+                )
+            )
         except ForbiddenError:
-            return InteractionResponse(action=ReplyAction(content="I have no permission to send a DM to the specified user."))
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("missing_dm_permission_error")
+            ))
         except UserNotFoundError:
-            return InteractionResponse(action=ReplyAction(content="I can't find the user you specified. Did you make a typo?"))
-        except (ServerNotFoundError, ChannelNotFoundError):
-            return InteractionResponse(action=DoNothingAction())
+            return InteractionResponse(ReplyAction(
+                content=self.__i18n_provider.get("user_not_found_error")
+            ))
+        except ServerNotFoundError:
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("server_not_found_error")
+            ))
+        except ChannelNotFoundError:
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("channel_not_found_error")
+            ))
 
-        return InteractionResponse(
-            action=ReplyAction(content="I've notified the user of their presence being required.")
-        )
+        return InteractionResponse(action=ReplyAction(
+            content=self.__i18n_provider.get(
+                "extensions.general.summon_user_workflow.successful_summon",
+                { "user_id": user_id }
+            ),
+            suppress_user_mentions=True
+        ))

--- a/holobot/extensions/general/workflows/view_bot_info_workflow.py
+++ b/holobot/extensions/general/workflows/view_bot_info_workflow.py
@@ -9,6 +9,7 @@ from holobot.discord.sdk.workflows.interactables.models import InteractionRespon
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.discord.sdk.data_providers import IBotDataProvider
 from holobot.discord.sdk.models import Embed, EmbedField, EmbedFooter
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.system import IEnvironment
 
@@ -17,27 +18,65 @@ class ViewBotInfoWorkflow(WorkflowBase):
     def __init__(
         self,
         bot_data_provider: IBotDataProvider,
-        environment: IEnvironment
+        environment: IEnvironment,
+        i18n_provider: II18nProvider
     ) -> None:
         super().__init__()
-        self.__bot_data_provider: IBotDataProvider = bot_data_provider
+        self.__bot_data_provider = bot_data_provider
         self.__environment = environment
+        self.__i18n_provider = i18n_provider
 
     @command(description="Displays some information about the bot.", name="info")
-    async def view_bot_info(self, context: ServerChatInteractionContext) -> InteractionResponse:
+    async def view_bot_info(
+        self,
+        context: ServerChatInteractionContext
+    ) -> InteractionResponse:
         current_time = datetime.now(tzlocal.get_localzone())
         return InteractionResponse(
-            action=ReplyAction(Embed(
-                title="Bot information",
-                description="Basic information about the bot.",
+            action=ReplyAction(content=Embed(
+                title=self.__i18n_provider.get(
+                    "extensions.general.view_bot_info_workflow.embed_title"
+                ),
+                description=self.__i18n_provider.get(
+                    "extensions.general.view_bot_info_workflow.embed_description"
+                ),
                 thumbnail_url=self.__bot_data_provider.get_avatar_url(),
                 fields=[
-                    EmbedField("Version", self.__environment.version.__str__()),
-                    EmbedField("Latency", f"{self.__bot_data_provider.get_latency():,.2f} ms"),
-                    EmbedField("Servers", str(self.__bot_data_provider.get_server_count())),
-                    EmbedField("Server time", f"{current_time:%I:%M:%S %p, %m/%d/%Y %Z}"),
-                    EmbedField("Repository", "https://github.com/rexor12/holobot")
+                    EmbedField(
+                        self.__i18n_provider.get(
+                            "extensions.general.view_bot_info_workflow.general_field"
+                        ),
+                        self.__i18n_provider.get(
+                            "extensions.general.view_bot_info_workflow.general_value",
+                            {
+                                "version": str(self.__environment.version),
+                                "latency": self.__bot_data_provider.get_latency(),
+                                "servers": self.__bot_data_provider.get_server_count(),
+                                "server_time": current_time
+                            }
+                        ),
+                        False
+                    ),
+                    EmbedField(
+                        self.__i18n_provider.get(
+                            "extensions.general.view_bot_info_workflow.project_home"
+                        ),
+                        "https://github.com/rexor12/holobot",
+                        False
+                    ),
+                    EmbedField(
+                        self.__i18n_provider.get(
+                            "extensions.general.view_bot_info_workflow.bug_reports"
+                        ),
+                        "https://github.com/rexor12/holobot/issues",
+                        False
+                    )
                 ],
-                footer=EmbedFooter("Brought to you by rexor12", "https://avatars.githubusercontent.com/u/15330052")
+                footer=EmbedFooter(
+                    self.__i18n_provider.get(
+                        "extensions.general.view_bot_info_workflow.embed_footer"
+                    ),
+                    "https://avatars.githubusercontent.com/u/15330052"
+                )
             ))
         )

--- a/holobot/extensions/general/workflows/view_emoji_workflow.py
+++ b/holobot/extensions/general/workflows/view_emoji_workflow.py
@@ -4,13 +4,19 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.discord.sdk.data_providers import IEmojiDataProvider
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class ViewEmojiWorkflow(WorkflowBase):
-    def __init__(self, emoji_data_provider: IEmojiDataProvider) -> None:
+    def __init__(
+        self,
+        emoji_data_provider: IEmojiDataProvider,
+        i18n_provider: II18nProvider
+    ) -> None:
         super().__init__()
         self.__emoji_data_provider: IEmojiDataProvider = emoji_data_provider
+        self.__i18n_provider = i18n_provider
 
     @command(
         description="Displays an emoji in a larger size.",
@@ -25,13 +31,13 @@ class ViewEmojiWorkflow(WorkflowBase):
         name: str
     ) -> InteractionResponse:
         if (emoji := await self.__emoji_data_provider.find_emoji(name.strip())) is None:
-            return InteractionResponse(
-                action=ReplyAction(content="The specified emoji cannot be found. Did you make a typo?")
-            )
+            return InteractionResponse(action=ReplyAction(content=self.__i18n_provider.get(
+                "extensions.general.view_emoji_workflow.emoji_not_found_error"
+            )))
 
         if not emoji.url:
-            return InteractionResponse(ReplyAction((
-                "The specified emoji isn't a custom emoji, therefore it has no attributes."
+            return InteractionResponse(ReplyAction(content=self.__i18n_provider.get(
+                "extensions.general.view_emoji_workflow.invalid_emoji_error"
             )))
 
         return InteractionResponse(

--- a/holobot/extensions/general/workflows/view_user_avatar_workflow.py
+++ b/holobot/extensions/general/workflows/view_user_avatar_workflow.py
@@ -1,15 +1,19 @@
 from typing import Optional
 
 from holobot.discord.sdk.actions import ReplyAction
+from holobot.discord.sdk.data_providers import IBotDataProvider
+from holobot.discord.sdk.exceptions import (
+    ChannelNotFoundError, ServerNotFoundError, UserNotFoundError
+)
+from holobot.discord.sdk.models import Embed, EmbedFooter
+from holobot.discord.sdk.servers import IMemberDataProvider
+from holobot.discord.sdk.utils import get_user_id
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
-from holobot.discord.sdk.data_providers import IBotDataProvider
-from holobot.discord.sdk.models import Embed, EmbedFooter
-from holobot.discord.sdk.servers import IMemberDataProvider
-from holobot.discord.sdk.utils import get_user_id
 from holobot.sdk.configs import ConfiguratorInterface
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
@@ -18,11 +22,13 @@ class ViewUserAvatarWorkflow(WorkflowBase):
         self,
         configurator: ConfiguratorInterface,
         bot_data_provider: IBotDataProvider,
+        i18n_provider: II18nProvider,
         member_data_provider: IMemberDataProvider
     ) -> None:
         super().__init__()
-        self.__bot_data_provider: IBotDataProvider = bot_data_provider
-        self.__member_data_provider: IMemberDataProvider = member_data_provider
+        self.__bot_data_provider = bot_data_provider
+        self.__i18n_provider = i18n_provider
+        self.__member_data_provider = member_data_provider
         self.__avatar_artwork_artist_name: str = configurator.get("General", "AvatarArtworkArtistName", "unknown")
 
     @command(
@@ -32,7 +38,11 @@ class ViewUserAvatarWorkflow(WorkflowBase):
             Option("user", "The name or mention of the user. By default, it's yourself.", is_mandatory=False),
         )
     )
-    async def execute(self, context: ServerChatInteractionContext, user: Optional[str] = None) -> InteractionResponse:
+    async def execute(
+        self,
+        context: ServerChatInteractionContext,
+        user: Optional[str] = None
+    ) -> InteractionResponse:
         try:
             if user is None:
                 member = self.__member_data_provider.get_basic_data_by_id(context.server_id, context.author_id)
@@ -40,19 +50,34 @@ class ViewUserAvatarWorkflow(WorkflowBase):
                 member = self.__member_data_provider.get_basic_data_by_id(context.server_id, user_id)
             else:
                 member = self.__member_data_provider.get_basic_data_by_name(context.server_id, user.strip())
-        except Exception:
-            # TODO guild/user not found
-            return InteractionResponse(
-                action=ReplyAction(content="The specified user cannot be found. Did you make a typo?")
-            )
+        except UserNotFoundError:
+            return InteractionResponse(ReplyAction(
+                content=self.__i18n_provider.get("user_not_found_error")
+            ))
+        except ServerNotFoundError:
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("server_not_found_error")
+            ))
+        except ChannelNotFoundError:
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("channel_not_found_error")
+            ))
 
         if member.user_id == self.__bot_data_provider.get_user_id():
-            footer = EmbedFooter(text=f"Artwork by {self.__avatar_artwork_artist_name}")
+            footer = EmbedFooter(
+                text=self.__i18n_provider.get(
+                    "extensions.general.view_user_avatar_workflow.embed_footer",
+                    { "artist": self.__avatar_artwork_artist_name }
+                )
+            )
         else: footer = None
         
         return InteractionResponse(
             action=ReplyAction(content=Embed(
-                title=f"{member.display_name}'s avatar",
+                title=self.__i18n_provider.get(
+                    "extensions.general.view_user_avatar_workflow.embed_title",
+                    { "user": member.display_name }
+                ),
                 image_url=member.avatar_url,
                 footer=footer
             ))

--- a/holobot/extensions/moderation/workflows/add_moderator_permission_workflow.py
+++ b/holobot/extensions/moderation/workflows/add_moderator_permission_workflow.py
@@ -9,13 +9,19 @@ from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import Choice, InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class AddModeratorPermissionWorkflow(WorkflowBase):
-    def __init__(self, permission_manager: IPermissionManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        permission_manager: IPermissionManager
+    ) -> None:
         super().__init__()
-        self.__permission_manager: IPermissionManager = permission_manager
+        self.__i18n_provider = i18n_provider
+        self.__permission_manager = permission_manager
 
     @moderation_command(
         description="Assign a moderator permission to a user.",
@@ -42,14 +48,29 @@ class AddModeratorPermissionWorkflow(WorkflowBase):
         user = user.strip()
         if (user_id := get_user_id(user)) is None:
             return InteractionResponse(
-                action=ReplyAction(content="You must mention a user correctly.")
+                action=ReplyAction(content=self.__i18n_provider.get("user_not_found_error"))
             )
+
         typed_permission = ModeratorPermission(permission)
         await self.__permission_manager.add_permissions(context.server_id, user_id, typed_permission)
+
+        permission_i18n = self.__i18n_provider.get(
+            f"extensions.moderation.permissions.{typed_permission.value}"
+        )
+
         return ModeratorPermissionsChangedResponse(
             author_id=context.author_id,
             user_id=user_id,
             permission=typed_permission,
             is_addition=True,
-            action=ReplyAction(content=f"{user} has had the permission to '{typed_permission.textify()}' _assigned_.")
+            action=ReplyAction(
+                suppress_user_mentions=True,
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.add_moderator_permission_workflow.permission_assigned",
+                    {
+                        "user_id": user_id,
+                        "permission": permission_i18n
+                    }
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/ban_user_workflow.py
+++ b/holobot/extensions/moderation/workflows/ban_user_workflow.py
@@ -15,21 +15,29 @@ from holobot.discord.sdk.utils import get_user_id
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.enums import MenuType, OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
-from holobot.discord.sdk.workflows.models import ServerChatInteractionContext, ServerUserInteractionContext
+from holobot.discord.sdk.workflows.models import (
+    ServerChatInteractionContext, ServerUserInteractionContext
+)
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
+
+_MIN_DAYS = 0
+_MAX_DAYS = 7
 
 @injectable(IWorkflow)
 class BanUserWorkflow(WorkflowBase):
     def __init__(
         self,
         config_provider: IConfigProvider,
+        i18n_provider: II18nProvider,
         messaging: IMessaging,
         user_manager: IUserManager
     ) -> None:
         super().__init__()
-        self.__config_provider: IConfigProvider = config_provider
-        self.__messaging: IMessaging = messaging
-        self.__user_manager: IUserManager = user_manager
+        self.__config_provider = config_provider
+        self.__i18n_provider = i18n_provider
+        self.__messaging = messaging
+        self.__user_manager = user_manager
 
     @moderation_command(
         description="Bans a user from the server. The user cannot rejoin until the ban is lifted.",
@@ -53,42 +61,71 @@ class BanUserWorkflow(WorkflowBase):
         reason = reason.strip()
         if (user_id := get_user_id(user)) is None:
             return InteractionResponse(
-                action=ReplyAction(content="You must mention a user correctly.")
+                action=ReplyAction(content=self.__i18n_provider.get("user_not_found_error"))
             )
+
         days = days if days is not None else 0
-        if days < 0 or days > 7:
+        if days < _MIN_DAYS or days > _MAX_DAYS:
             return InteractionResponse(
-                action=ReplyAction(content="The days parameter's value must be between 0 and 7. If omitted, no messages are deleted.")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.days_out_of_range_error",
+                    { "min": _MIN_DAYS, "max": _MAX_DAYS }
+                ))
             )
+
         reason_length_range = self.__config_provider.get_reason_length_range()
         if len(reason) not in reason_length_range:
             return InteractionResponse(
-                action=ReplyAction(content=f"The reason parameter's length must be between {reason_length_range.lower_bound} and {reason_length_range.upper_bound}.")
+                action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.moderation.reason_out_of_range_error",
+                        { "min": reason_length_range.lower_bound, "max": reason_length_range.upper_bound }
+                    )
+                )
             )
 
         try:
             await self.__user_manager.ban_user(context.server_id, user_id, reason, days)
         except UserNotFoundError:
-            return InteractionResponse(
-                action=ReplyAction(content="The user you mentioned cannot be found.")
-            )
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get("user_not_found_error")
+            ))
         except ForbiddenError:
-            return InteractionResponse(
-                action=ReplyAction(content=(
-                    "I cannot ban the user.\n"
-                    "Have you given me user management permissions?\n"
-                    "Do they have a role ranking higher than mine?"
-                ))
-            )
+            return InteractionResponse(action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.cannot_ban_user_error",
+                    { "user_id": user_id }
+                ),
+                suppress_user_mentions=True
+            ))
 
         with contextlib.suppress(ForbiddenError):
-            await self.__messaging.send_private_message(user_id, f"You have been banned from {context.server_name} by {context.author_name} with the reason '{reason}'. I'm sorry this happened to you.")
+            await self.__messaging.send_private_message(
+                user_id,
+                self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.user_banned_dm",
+                    {
+                        "user_name": context.author_name,
+                        "server_name": context.server_name,
+                        "reason": reason
+                    }
+                )
+            )
 
         return UserBannedInteractionResponse(
             author_id=context.author_id,
             user_id=user_id,
             reason=reason,
-            action=ReplyAction(content=f"<@{user_id}> has been banned. Reason: {reason}")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.user_banned",
+                    {
+                        "user_id": user_id,
+                        "reason": reason
+                    }
+                ),
+                suppress_user_mentions=True
+            )
         )
 
     @moderation_menu_item(
@@ -106,25 +143,40 @@ class BanUserWorkflow(WorkflowBase):
         except UserNotFoundError:
             return InteractionResponse(
                 action=ReplyAction(
-                    content="The specified user cannot be found."
+                    content=self.__i18n_provider.get("user_not_found_error")
                 )
             )
         except ForbiddenError:
             return InteractionResponse(
-                action=ReplyAction(content=(
-                    "I cannot kick the user.\n"
-                    "Have you given me user management permissions?\n"
-                    "Do they have a role ranking higher than mine?"
-                ))
+                action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.moderation.ban_user_workflow.cannot_ban_user_error",
+                        { "user_id": context.target_user_id }
+                    ),
+                    suppress_user_mentions=True
+                )
             )
 
         with contextlib.suppress(ForbiddenError):
-            await self.__messaging.send_private_message(context.target_user_id, f"You have been banned from {context.server_name} by {context.author_name}. I'm sorry this happened to you.")
+            await self.__messaging.send_private_message(
+                context.target_user_id,
+                self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.user_banned_dm_no_reason",
+                    {
+                        "user_name": context.author_name,
+                        "server_name": context.server_name
+                    }
+                )
+            )
 
         return UserBannedMenuItemResponse(
             author_id=context.author_id,
             user_id=context.target_user_id,
             action=ReplyAction(
-                content=f"<@{context.target_user_id}> has been banned."
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.ban_user_workflow.user_banned_no_reason",
+                    { "user_id": context.target_user_id }
+                ),
+                suppress_user_mentions=True
             )
         )

--- a/holobot/extensions/moderation/workflows/clear_log_channel_workflow.py
+++ b/holobot/extensions/moderation/workflows/clear_log_channel_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class ClearLogChannelWorkflow(WorkflowBase):
-    def __init__(self, log_manager: ILogManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        log_manager: ILogManager
+    ) -> None:
         super().__init__()
-        self.__log_manager: ILogManager = log_manager
+        self.__i18n_provider = i18n_provider
+        self.__log_manager = log_manager
     
     @moderation_command(
         description="Disables the logging of moderation actions.",
@@ -28,5 +34,9 @@ class ClearLogChannelWorkflow(WorkflowBase):
         await self.__log_manager.set_log_channel(context.server_id, None)
         return LogChannelToggledResponse(
             author_id=context.author_id,
-            action=ReplyAction(content="Moderation actions won't be logged anymore.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.clear_log_channel_workflow.logs_disabled"
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/disable_auto_ban_workflow.py
+++ b/holobot/extensions/moderation/workflows/disable_auto_ban_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class DisableAutoBanWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Disables automatic user banishment.",
@@ -28,5 +34,9 @@ class DisableAutoBanWorkflow(WorkflowBase):
         await self.__warn_manager.disable_auto_ban(context.server_id)
         return AutoBanToggledResponse(
             author_id=context.author_id,
-            action=ReplyAction(content="Users won't be banned automatically anymore.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.disable_auto_ban_workflow.auto_ban_disabled"
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/disable_auto_kick_workflow.py
+++ b/holobot/extensions/moderation/workflows/disable_auto_kick_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class DisableAutoKickWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Disables automatic user kicking.",
@@ -28,5 +34,9 @@ class DisableAutoKickWorkflow(WorkflowBase):
         await self.__warn_manager.disable_auto_kick(context.server_id)
         return AutoKickToggledResponse(
             author_id=context.author_id,
-            action=ReplyAction(content="Users won't be kicked automatically anymore.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.disable_auto_kick_workflow.auto_kick_disabled"
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/disable_auto_mute_workflow.py
+++ b/holobot/extensions/moderation/workflows/disable_auto_mute_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class DisableAutoMuteWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Disables automatic user muting.",
@@ -25,5 +31,9 @@ class DisableAutoMuteWorkflow(WorkflowBase):
         await self.__warn_manager.disable_auto_mute(context.server_id)
         return AutoMuteToggledResponse(
             author_id=context.author_id,
-            action=ReplyAction(content="Users won't be muted automatically anymore.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.disable_auto_mute_workflow.auto_mute_disabled"
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/disable_warn_decay_workflow.py
+++ b/holobot/extensions/moderation/workflows/disable_warn_decay_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class DisableWarnDecayWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Disables automatic warn strike removal.",
@@ -28,5 +34,9 @@ class DisableWarnDecayWorkflow(WorkflowBase):
         await self.__warn_manager.set_warn_decay(context.server_id, None)
         return WarnDecayToggledResponse(
             author_id=context.author_id,
-            action=ReplyAction(content="Warn strikes won't be removed automatically anymore.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.disable_warn_decay_workflow.auto_warn_disabled"
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/set_auto_kick_workflow.py
+++ b/holobot/extensions/moderation/workflows/set_auto_kick_workflow.py
@@ -8,13 +8,19 @@ from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.sdk.exceptions import ArgumentOutOfRangeError
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class SetAutoKickWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Enables automatic kicking of people with warn strikes.",
@@ -35,12 +41,22 @@ class SetAutoKickWorkflow(WorkflowBase):
             await self.__warn_manager.enable_auto_kick(context.server_id, warn_count)
         except ArgumentOutOfRangeError as error:
             return InteractionResponse(
-                action=ReplyAction(content=f"The warn count must be between {error.lower_bound} and {error.upper_bound}.")
+                action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.moderation.warn_count_out_of_range_error",
+                        { "min": error.lower_bound, "max": error.upper_bound }
+                    )
+                )
             )
 
         return AutoKickToggledResponse(
             author_id=context.author_id,
             is_enabled=True,
             warn_count=warn_count,
-            action=ReplyAction(content="Auto kick has been configured.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.set_auto_kick_workflow.autokick_configured",
+                    { "warns": warn_count }
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/set_warn_decay_workflow.py
+++ b/holobot/extensions/moderation/workflows/set_warn_decay_workflow.py
@@ -8,13 +8,20 @@ from holobot.discord.sdk.workflows.interactables.models import InteractionRespon
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.sdk.chrono import parse_interval
 from holobot.sdk.exceptions import ArgumentOutOfRangeError
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
+from holobot.sdk.utils import textify_timedelta
 
 @injectable(IWorkflow)
 class SetWarnDecayWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Enables automatic warn strike removal.",
@@ -36,12 +43,22 @@ class SetWarnDecayWorkflow(WorkflowBase):
             await self.__warn_manager.set_warn_decay(context.server_id, decay_threshold)
         except ArgumentOutOfRangeError as error:
             return InteractionResponse(
-                action=ReplyAction(content=f"The duration must be between {error.lower_bound} and {error.upper_bound}.")
+                action=ReplyAction(
+                    content=self.__i18n_provider.get(
+                        "extensions.moderation.duration_out_of_range_error",
+                        { "min": error.lower_bound, "max": error.upper_bound }
+                    )
+                )
             )
 
         return WarnDecayToggledResponse(
             author_id=context.author_id,
             is_enabled=True,
             duration=decay_threshold,
-            action=ReplyAction(content="The warn decay time has been set.")
+            action=ReplyAction(
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.set_warn_decay_workflow.decay_configured",
+                    { "decay_time": textify_timedelta(decay_threshold) }
+                )
+            )
         )

--- a/holobot/extensions/moderation/workflows/view_warn_decay_workflow.py
+++ b/holobot/extensions/moderation/workflows/view_warn_decay_workflow.py
@@ -5,14 +5,20 @@ from holobot.discord.sdk.enums import Permission
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.utils import textify_timedelta
 
 @injectable(IWorkflow)
 class ViewWarnDecayWorkflow(WorkflowBase):
-    def __init__(self, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__i18n_provider = i18n_provider
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Displays the currently set warn decay.",
@@ -26,7 +32,17 @@ class ViewWarnDecayWorkflow(WorkflowBase):
         context: ServerChatInteractionContext
     ) -> InteractionResponse:
         decay_threshold = await self.__warn_manager.get_warn_decay(context.server_id)
+        response_i18n = (
+            "extensions.moderation.view_warn_decay_workflow.decay_enabled"
+            if decay_threshold
+            else "extensions.moderation.view_warn_decay_workflow.decay_disabled"
+        )
+
         return InteractionResponse(action=ReplyAction(
-            content=f"The warn decay is set to {textify_timedelta(decay_threshold)}."
-                    if decay_threshold else "There is no warn decay set for the server."
+            content=self.__i18n_provider.get(
+                response_i18n,
+                {
+                    "time": textify_timedelta(decay_threshold)
+                }
+            )
         ))

--- a/holobot/extensions/moderation/workflows/view_warn_strikes_workflow.py
+++ b/holobot/extensions/moderation/workflows/view_warn_strikes_workflow.py
@@ -57,8 +57,15 @@ class ViewWarnStrikesWorkflow(WorkflowBase):
                 action=ReplyAction(content="The user you mentioned cannot be found.")
             )
 
+        content, components = await self.__create_page_content(
+            context.server_id,
+            user_id,
+            0,
+            DEFAULT_PAGE_SIZE
+        )
         return InteractionResponse(ReplyAction(
-            *await self.__create_page_content(context.server_id, user_id, 0, DEFAULT_PAGE_SIZE)
+            content=content,
+            components=components
         ))
 
     @moderation_component(
@@ -74,19 +81,21 @@ class ViewWarnStrikesWorkflow(WorkflowBase):
         state: Any
     ) -> InteractionResponse:
         if not isinstance(context, ServerChatInteractionContext):
-            return InteractionResponse(EditMessageAction("An internal error occurred while processing the interaction."))
+            return InteractionResponse(EditMessageAction(content="An internal error occurred while processing the interaction."))
 
+        content, components = await self.__create_page_content(
+            context.server_id,
+            state.owner_id,
+            max(state.current_page, 0),
+            DEFAULT_PAGE_SIZE
+        )
         return InteractionResponse(
             EditMessageAction(
-                *await self.__create_page_content(
-                    context.server_id,
-                    state.owner_id,
-                    max(state.current_page, 0),
-                    DEFAULT_PAGE_SIZE
-                )
+                content=content,
+                components=components
             )
             if isinstance(state, PagerState)
-            else EditMessageAction("An internal error occurred while processing the interaction.")
+            else EditMessageAction(content="An internal error occurred while processing the interaction.")
         )
 
     async def __create_page_content(

--- a/holobot/extensions/moderation/workflows/warn_user_workflow.py
+++ b/holobot/extensions/moderation/workflows/warn_user_workflow.py
@@ -14,17 +14,28 @@ from holobot.discord.sdk.utils import get_user_id
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.enums import MenuType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
-from holobot.discord.sdk.workflows.models import ServerChatInteractionContext, ServerUserInteractionContext
+from holobot.discord.sdk.workflows.models import (
+    ServerChatInteractionContext, ServerUserInteractionContext
+)
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class WarnUserWorkflow(WorkflowBase):
-    def __init__(self, config_provider: IConfigProvider, member_data_provider: IMemberDataProvider, messaging: IMessaging, warn_manager: IWarnManager) -> None:
+    def __init__(
+        self,
+        config_provider: IConfigProvider,
+        i18n_provider: II18nProvider,
+        member_data_provider: IMemberDataProvider,
+        messaging: IMessaging,
+        warn_manager: IWarnManager
+    ) -> None:
         super().__init__()
-        self.__config_provider: IConfigProvider = config_provider
-        self.__member_data_provider: IMemberDataProvider = member_data_provider
-        self.__messaging: IMessaging = messaging
-        self.__warn_manager: IWarnManager = warn_manager
+        self.__config_provider = config_provider
+        self.__i18n_provider = i18n_provider
+        self.__member_data_provider = member_data_provider
+        self.__messaging = messaging
+        self.__warn_manager = warn_manager
 
     @moderation_command(
         description="Warns a user, giving them one warn strike.",
@@ -46,35 +57,53 @@ class WarnUserWorkflow(WorkflowBase):
         reason = reason.strip()
         if (user_id := get_user_id(user)) is None:
             return InteractionResponse(
-                action=ReplyAction(
-                    content="You must mention a user correctly."
-                )
+                action=ReplyAction(content=self.__i18n_provider.get("user_not_found_error"))
             )
 
         reason_length_range = self.__config_provider.get_reason_length_range()
         if len(reason) not in reason_length_range:
             return InteractionResponse(
                 action=ReplyAction(
-                    content=f"The reason parameter's length must be between {reason_length_range.lower_bound} and {reason_length_range.upper_bound}."
+                    content=self.__i18n_provider.get(
+                        "extensions.moderation.reason_out_of_range_error",
+                        { "min": reason_length_range.lower_bound, "max": reason_length_range.upper_bound }
+                    )
                 )
             )
 
         if not self.__member_data_provider.is_member(context.server_id, user_id):
             return InteractionResponse(
-                action=ReplyAction(content="The user you mentioned cannot be found.")
+                action=ReplyAction(content=self.__i18n_provider.get("user_not_found_error"))
             )
 
         await self.__warn_manager.warn_user(context.server_id, user_id, reason, context.author_id)
 
         with contextlib.suppress(ForbiddenError):
-            await self.__messaging.send_private_message(user_id, f"You have been warned in {context.server_name} by {context.author_name} with the reason '{reason}'. Maybe you should behave yourself.")
+            await self.__messaging.send_private_message(
+                user_id,
+                self.__i18n_provider.get(
+                    "extensions.moderation.warn_user_workflow.user_warned_dm",
+                    {
+                        "user_name": context.author_name,
+                        "server_name": context.server_name,
+                        "reason": reason
+                    }
+                )
+            )
 
         return UserWarnedInteractionResponse(
             author_id=context.author_id,
             user_id=user_id,
             reason=reason,
             action=ReplyAction(
-                content=f"<@{user_id}> has been warned. Reason: {reason}"
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.warn_user_workflow.user_warned",
+                    {
+                        "user_id": user_id,
+                        "reason": reason
+                    }
+                ),
+                suppress_user_mentions=True
             )
         )
 
@@ -90,18 +119,31 @@ class WarnUserWorkflow(WorkflowBase):
     ) -> InteractionResponse:
         if not self.__member_data_provider.is_member(context.server_id, context.target_user_id):
             return InteractionResponse(
-                action=ReplyAction(content="The user you mentioned cannot be found.")
+                action=ReplyAction(content=self.__i18n_provider.get("user_not_found_error"))
             )
 
         await self.__warn_manager.warn_user(context.server_id, context.target_user_id, "Issued via menu item", context.author_id)
 
         with contextlib.suppress(ForbiddenError):
-            await self.__messaging.send_private_message(context.target_user_id, f"You have been warned in {context.server_name} by {context.author_name}. Maybe you should behave yourself.")
+            await self.__messaging.send_private_message(
+                context.target_user_id,
+                self.__i18n_provider.get(
+                    "extensions.moderation.warn_user_workflow.user_warned_dm_no_reason",
+                    {
+                        "user_name": context.author_name,
+                        "server_name": context.server_name
+                    }
+                )
+            )
 
         return UserWarnedMenuItemResponse(
             author_id=context.author_id,
             user_id=context.target_user_id,
             action=ReplyAction(
-                content=f"<@{context.target_user_id}> has been warned."
+                content=self.__i18n_provider.get(
+                    "extensions.moderation.warn_user_workflow.user_warned_no_reason",
+                    { "user_id": context.target_user_id }
+                ),
+                suppress_user_mentions=True
             )
         )

--- a/holobot/extensions/reminders/reminder_manager.py
+++ b/holobot/extensions/reminders/reminder_manager.py
@@ -6,7 +6,7 @@ from .models import Reminder, ReminderConfig
 from .reminder_manager_interface import ReminderManagerInterface
 from .repositories import ReminderRepositoryInterface
 from holobot.sdk.configs import ConfiguratorInterface
-from holobot.sdk.exceptions import ArgumentError
+from holobot.sdk.exceptions import ArgumentError, ArgumentOutOfRangeError
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.logging import ILoggerFactory
 from holobot.sdk.queries import PaginationResult
@@ -28,12 +28,16 @@ class ReminderManager(ReminderManagerInterface):
         
     async def set_reminder(self, user_id: str, config: ReminderConfig) -> Reminder:
         if not (self.__message_length_min <= len(config.message) <= self.__message_length_max):
-            raise ArgumentError("message", f"The length of the message must be between {self.__message_length_min} and {self.__message_length_max} characters.")
+            raise ArgumentOutOfRangeError(
+                "message",
+                str(self.__message_length_min),
+                str(self.__message_length_max)
+            )
         if config.every_interval is not None and config.in_time is not None:
             raise InvalidReminderConfigError("every", "in")
         if config.in_time is not None and config.at_time is not None:
             raise InvalidReminderConfigError("in", "at")
-        
+
         await self.__assert_reminder_count(user_id)
         if config.every_interval is not None:
             reminder = await self.__set_recurring_reminder(user_id, config.message, config.every_interval, config.at_time)
@@ -52,7 +56,7 @@ class ReminderManager(ReminderManagerInterface):
     async def delete_reminder(self, user_id: str, reminder_id: int) -> None:
         if user_id is None or len(user_id) == 0:
             raise ArgumentError("user_id", "The user identifier must not be empty.")
-        
+
         deleted_count = await self.__reminder_repository.delete_by_user(user_id, reminder_id)
         if deleted_count == 0:
             raise InvalidReminderError("The specified reminder doesn't exist or belong to the specified user.")
@@ -75,7 +79,7 @@ class ReminderManager(ReminderManagerInterface):
         reminder.recalculate_next_trigger()
         await self.__reminder_repository.store(reminder)
         return reminder
-    
+
     async def __set_single_reminder(self, user_id: str, message: str, next_trigger: datetime) -> Reminder:
         reminder = Reminder()
         reminder.user_id = user_id
@@ -83,15 +87,15 @@ class ReminderManager(ReminderManagerInterface):
         reminder.next_trigger = next_trigger
         await self.__reminder_repository.store(reminder)
         return reminder
-    
+
     def __calculate_recurring_base_trigger(self, frequency_time: timedelta, at_time: Optional[timedelta]):
         current_time = datetime.utcnow()
         if at_time is None:
             return current_time
-        
+
         base_trigger = datetime(current_time.year, current_time.month, current_time.day) + at_time
         return base_trigger - frequency_time if base_trigger > current_time else base_trigger
-    
+
     def __calculate_single_trigger_at(self, at_time: timedelta) -> datetime:
         # TODO Make this aware of the user's locale. We can't expect random people to deal with UTC.
         # https://discordpy.readthedocs.io/en/stable/api.html#discord.ClientUser.locale

--- a/holobot/extensions/reminders/workflows/remove_reminder_workflow.py
+++ b/holobot/extensions/reminders/workflows/remove_reminder_workflow.py
@@ -6,6 +6,7 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.logging import ILoggerFactory
 
@@ -13,12 +14,14 @@ from holobot.sdk.logging import ILoggerFactory
 class RemoveReminderWorkflow(WorkflowBase):
     def __init__(
         self,
+        i18n_provider: II18nProvider,
         logger_factory: ILoggerFactory,
         reminder_manager: ReminderManagerInterface
     ) -> None:
         super().__init__()
+        self.__i18n_provider = i18n_provider
         self.__logger = logger_factory.create(RemoveReminderWorkflow)
-        self.__reminder_manager: ReminderManagerInterface = reminder_manager
+        self.__reminder_manager = reminder_manager
 
     @command(
         description="Removes a reminder.",
@@ -38,12 +41,16 @@ class RemoveReminderWorkflow(WorkflowBase):
             self.__logger.debug("Deleted a reminder", user_id=context.author_id, reminder_id=id)
             return InteractionResponse(
                 action=ReplyAction(
-                    content="The reminder has been deleted."
+                    content=self.__i18n_provider.get(
+                        "extensions.reminders.remove_reminder_workflow.reminder_deleted"
+                    )
                 )
             )
         except InvalidReminderError:
             return InteractionResponse(
                 action=ReplyAction(
-                    content="That reminder doesn't exist or belong to you."
+                    content=self.__i18n_provider.get(
+                        "extensions.reminders.remove_reminder_workflow.reminder_not_found_error"
+                    )
                 )
             )

--- a/holobot/extensions/server/workflows/view_server_icon_workflow.py
+++ b/holobot/extensions/server/workflows/view_server_icon_workflow.py
@@ -1,39 +1,54 @@
 from holobot.discord.sdk.actions import ReplyAction
 from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
-from holobot.discord.sdk.workflows.interactables.enums import OptionType
-from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
+from holobot.discord.sdk.workflows.interactables.models import InteractionResponse
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.discord.sdk.exceptions import ServerNotFoundError
 from holobot.discord.sdk.models import Embed
 from holobot.discord.sdk.servers import IServerDataProvider
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class ViewServerIconWorkflow(WorkflowBase):
-    def __init__(self, server_data_provider: IServerDataProvider) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        server_data_provider: IServerDataProvider
+    ) -> None:
         super().__init__()
-        self.__server_data_provider: IServerDataProvider = server_data_provider
+        self.__i18n_provider = i18n_provider
+        self.__server_data_provider = server_data_provider
 
     @command(
         description="Displays the server's icon.",
         name="icon",
         group_name="server"
     )
-    async def display_server_icon(self, context: ServerChatInteractionContext) -> InteractionResponse:
+    async def display_server_icon(
+        self,
+        context: ServerChatInteractionContext
+    ) -> InteractionResponse:
         try:
             server = self.__server_data_provider.get_basic_data_by_id(context.server_id)
         except ServerNotFoundError:
             return InteractionResponse(
-                action=ReplyAction(content="The server cannot be found.")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.server.view_server_icon_workflow.unknown_server_error"
+                ))
             )
-        
+
         if not server.icon_url:
-            return InteractionResponse(action=ReplyAction(content="The server doesn't have an icon."))
+            return InteractionResponse(ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.server.view_server_icon_workflow.no_server_icon"
+                )))
         
         return InteractionResponse(
             action=ReplyAction(content=Embed(
-                title=f"{server.name}'s icon",
+                title=self.__i18n_provider.get(
+                    "extensions.server.view_server_icon_workflow.embed_title",
+                    { "name": server.name }
+                ),
                 image_url=server.icon_url
             ))
         )

--- a/holobot/extensions/todo_lists/workflows/add_todo_item_workflow.py
+++ b/holobot/extensions/todo_lists/workflows/add_todo_item_workflow.py
@@ -7,6 +7,7 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
 from holobot.sdk.exceptions import ArgumentOutOfRangeError
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.logging import ILoggerFactory
 
@@ -14,12 +15,14 @@ from holobot.sdk.logging import ILoggerFactory
 class AddTodoItemWorkflow(WorkflowBase):
     def __init__(
         self,
+        i18n_provider: II18nProvider,
         logger_factory: ILoggerFactory,
         todo_item_manager: TodoItemManagerInterface
     ) -> None:
         super().__init__()
+        self.__i18n_provider = i18n_provider
         self.__logger = logger_factory.create(AddTodoItemWorkflow)
-        self.__todo_item_manager: TodoItemManagerInterface = todo_item_manager
+        self.__todo_item_manager = todo_item_manager
 
     @command(
         description="Adds a new item to your to-do list.",
@@ -41,18 +44,28 @@ class AddTodoItemWorkflow(WorkflowBase):
             await self.__todo_item_manager.add_todo_item(todo_item)
             return InteractionResponse(
                 action=ReplyAction(
-                    content="The item has been added to your to-do list."
+                    content=self.__i18n_provider.get(
+                        "extensions.todo_lists.add_todo_item_workflow.item_added"
+                    )
                 )
             )
         except ArgumentOutOfRangeError as error:
             return InteractionResponse(
                 action=ReplyAction(
-                    content=f"Your message's length has to be between {error.lower_bound} and {error.upper_bound}."
+                    content=self.__i18n_provider.get(
+                        "extensions.todo_lists.add_todo_item_workflow.message_too_long_error",
+                        {
+                            "lower_bound": error.lower_bound,
+                            "upper_bound": error.upper_bound
+                        }
+                    )
                 )
             )
         except TooManyTodoItemsError:
             return InteractionResponse(
                 action=ReplyAction(
-                    content="You have reached the maximum number of to-do items. Please, remove at least one to be able to add this new one."
+                    content=self.__i18n_provider.get(
+                        "extensions.todo_lists.add_todo_item_workflow.list_full_error"
+                    )
                 )
             )

--- a/holobot/extensions/todo_lists/workflows/remove_all_todo_items_workflow.py
+++ b/holobot/extensions/todo_lists/workflows/remove_all_todo_items_workflow.py
@@ -4,31 +4,37 @@ from holobot.discord.sdk.workflows import IWorkflow, WorkflowBase
 from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class RemoveAllTodoItemsWorkflow(WorkflowBase):
-    def __init__(self, todo_item_manager: TodoItemManagerInterface) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        todo_item_manager: TodoItemManagerInterface
+    ) -> None:
         super().__init__()
-        self.__todo_item_manager: TodoItemManagerInterface = todo_item_manager
-        self.group_name = "todo"
-        self.description = "Removes all to-do items from your list."
+        self.__i18n_provider = i18n_provider
+        self.__todo_item_manager = todo_item_manager
 
     @command(
         description="Removes ALL to-do items from your list.",
         name="removeall",
-        group_name="todo",
-        options=(
-            Option("description", "The description of the to-do item."),
-        )
+        group_name="todo"
     )
     async def remove_all_todo_items(self, context: ServerChatInteractionContext) -> InteractionResponse:
         deleted_count = await self.__todo_item_manager.delete_all(context.author_id)
         if deleted_count > 0:
             return InteractionResponse(
-                action=ReplyAction(content=f"All {deleted_count} of your to-do items have been removed.")
+                action=ReplyAction(content=self.__i18n_provider.get(
+                    "extensions.todo_lists.remove_all_todo_items_workflow.items_deleted",
+                    { "count": deleted_count }
+                ))
             )
 
         return InteractionResponse(
-            action=ReplyAction(content="You have no to-do items to be removed.")
+            action=ReplyAction(content=self.__i18n_provider.get(
+                "extensions.todo_lists.remove_all_todo_items_workflow.no_todo_items_error"
+            ))
         )

--- a/holobot/extensions/todo_lists/workflows/remove_todo_item_workflow.py
+++ b/holobot/extensions/todo_lists/workflows/remove_todo_item_workflow.py
@@ -6,13 +6,19 @@ from holobot.discord.sdk.workflows.interactables.decorators import command
 from holobot.discord.sdk.workflows.interactables.enums import OptionType
 from holobot.discord.sdk.workflows.interactables.models import InteractionResponse, Option
 from holobot.discord.sdk.workflows.models import ServerChatInteractionContext
+from holobot.sdk.i18n import II18nProvider
 from holobot.sdk.ioc.decorators import injectable
 
 @injectable(IWorkflow)
 class RemoveTodoItemWorkflow(WorkflowBase):
-    def __init__(self, todo_item_manager: TodoItemManagerInterface) -> None:
+    def __init__(
+        self,
+        i18n_provider: II18nProvider,
+        todo_item_manager: TodoItemManagerInterface
+    ) -> None:
         super().__init__()
-        self.__todo_item_manager: TodoItemManagerInterface = todo_item_manager
+        self.__i18n_provider = i18n_provider
+        self.__todo_item_manager = todo_item_manager
     
     @command(
         description="Removes a to-do item from your list.",
@@ -31,12 +37,16 @@ class RemoveTodoItemWorkflow(WorkflowBase):
             await self.__todo_item_manager.delete_by_user(context.author_id, identifier)
             return InteractionResponse(
                 action=ReplyAction(
-                    content="The to-do item has been deleted."
+                    content=self.__i18n_provider.get(
+                        "extensions.todo_lists.remove_todo_item_workflow.item_deleted"
+                    )
                 )
             )
         except InvalidTodoItemError:
             return InteractionResponse(
                 action=ReplyAction(
-                    content="That to-do item doesn't exist or belong to you."
+                    content=self.__i18n_provider.get(
+                        "extensions.todo_lists.remove_todo_item_workflow.no_todo_item_error"
+                    )
                 )
             )

--- a/holobot/framework/i18n/__init__.py
+++ b/holobot/framework/i18n/__init__.py
@@ -1,0 +1,1 @@
+from .i18n_provider import I18nProvider

--- a/holobot/framework/i18n/i18n_provider.py
+++ b/holobot/framework/i18n/i18n_provider.py
@@ -1,0 +1,136 @@
+from json import load
+from typing import Any
+
+import glob
+import os
+
+from .types import I18nGroup
+from holobot.sdk.i18n import II18nProvider
+from holobot.sdk.ioc.decorators import injectable
+from holobot.sdk.lifecycle import IStartable
+from holobot.sdk.system import IEnvironment
+
+_ARGUMENTS_SENTINEL: dict[str, Any] = {}
+_DEFAULT_LANGUAGE = "default"
+
+@injectable(IStartable)
+@injectable(II18nProvider)
+class I18nProvider(II18nProvider, IStartable):
+    """Implementation of a service used to resolve internationalization keys."""
+
+    def __init__(
+        self,
+        environment: IEnvironment
+    ) -> None:
+        super().__init__()
+        self.__environment = environment
+        self.__languages: dict[str, I18nGroup] = {}
+
+    async def start(self):
+        languages: dict[str, I18nGroup] = {}
+        i18n_directory = os.path.join(self.__environment.root_path, "resources", "i18n")
+        for file_name in glob.glob("*.json", root_dir=i18n_directory):
+            file_info = os.path.splitext(file_name)
+            name_parts = file_info[0].split("_")
+            language = _DEFAULT_LANGUAGE if len(name_parts) < 2 else name_parts[1]
+            languages[language] = I18nProvider.__build_map(
+                os.path.join(i18n_directory, file_name)
+            )
+        self.__languages = languages
+
+    async def stop(self):
+        pass
+
+    def get(
+        self,
+        key: str,
+        arguments: dict[str, Any] | None = None,
+        language: str | None = None
+    ) -> str:
+        if arguments is None:
+            arguments = _ARGUMENTS_SENTINEL
+        value = self.__resolve_formatted_key_by_language(key, arguments, language)
+        return value if isinstance(value, str) else key
+
+    def get_list(
+        self,
+        key: str,
+        language: str | None = None,
+    ) -> tuple[str, ...]:
+        value = self.__resolve_formatted_key_by_language(key, _ARGUMENTS_SENTINEL, language)
+        return value if isinstance(value, tuple) else ()
+
+    @staticmethod
+    def __build_map(file_path: str) -> I18nGroup:
+        with open(file_path, encoding="utf-8") as file:
+            json = load(file)
+            if not isinstance(json, dict):
+                raise ValueError(f"The file at the specified path '{file_path}' is not a valid I18N JSON file.")
+
+        root_group = I18nGroup(name="root")
+        nodes: list[tuple[I18nGroup, dict[str, Any]]] = [(root_group, json)]
+        while nodes:
+            parent_group, json = nodes.pop(0)
+            for name, value in json.items():
+                if isinstance(value, dict):
+                    child_group = I18nGroup(name=name)
+                    parent_group.value[name] = child_group
+                    nodes.append((child_group, value))
+                elif isinstance(value, list):
+                    parent_group.value[name] = tuple(v for v in value if isinstance(v, str))
+                elif isinstance(value, str):
+                    parent_group.value[name] = value
+        return root_group
+
+    @staticmethod
+    def __resolve_key(
+        group: I18nGroup,
+        subkeys: list[str]
+    ) -> str | tuple[str, ...] | None:
+        current_group = group
+        for subkey in subkeys[:-1]:
+            current_group = current_group.value.get(subkey)
+            if not isinstance(current_group, I18nGroup):
+                return None
+
+        value = current_group.value.get(subkeys[-1])
+        return None if isinstance(value, I18nGroup) else value
+
+    @staticmethod
+    def __resolve_formatted_key(
+        group: I18nGroup,
+        subkeys: list[str],
+        arguments: dict[str, Any]
+    ) -> str | tuple[str, ...] | None:
+        value = I18nProvider.__resolve_key(group, subkeys)
+        if isinstance(value, tuple):
+            return value
+
+        return value.format(**arguments) if value else None
+
+    def __resolve_formatted_key_by_language(
+        self,
+        key: str,
+        arguments: dict[str, Any],
+        language: str | None = None
+    ) -> str | tuple[str, ...] | None:
+        subkeys = key.split(".")
+        language_map = self.__languages.get(language) if language else None
+        has_checked_default = False
+        if not language_map:
+            language_map = self.__languages.get(_DEFAULT_LANGUAGE)
+            has_checked_default = True
+        if not language_map:
+            return key
+        value = I18nProvider.__resolve_formatted_key(language_map, subkeys, arguments)
+        if value is not None:
+            return value
+        if has_checked_default:
+            return key
+
+        language_map = self.__languages.get(_DEFAULT_LANGUAGE)
+        value = (
+            I18nProvider.__resolve_formatted_key(language_map, subkeys, arguments)
+            if language_map else None
+        )
+        return key if value is None else value

--- a/holobot/framework/i18n/types.py
+++ b/holobot/framework/i18n/types.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+@dataclass(kw_only=True, frozen=True)
+class I18nGroup:
+    name: str
+    value: dict[str, I18nGroup | str | tuple[str, ...]] = field(default_factory=dict)

--- a/holobot/sdk/i18n/__init__.py
+++ b/holobot/sdk/i18n/__init__.py
@@ -1,0 +1,1 @@
+from .ii18n_provider import II18nProvider

--- a/holobot/sdk/i18n/ii18n_provider.py
+++ b/holobot/sdk/i18n/ii18n_provider.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, Protocol
+
+class II18nProvider(Protocol):
+    """Interface for a service used to resolve internationalization keys."""
+
+    def get(
+        self,
+        key: str,
+        arguments: Dict[str, Any] | None = None,
+        language: str | None = None,
+    ) -> str:
+        """Gets the formatted text associated to the specified key.
+
+        - If there is no value associated to the specified key, the key is returned.
+        - If there is no value associated to the specified key in the specified language,
+        the default translation is returned (or the key, as per the above).
+
+        :param key: The I18N key used to identify the resource.
+        :type key: str
+        :param arguments: An optional key-value pair collection to resolve text templates, defaults to None
+        :type arguments: Dict[str, Any] | None, optional
+        :param language: An optional language for which to get the translation, defaults to None
+        :type language: str | None, optional
+        :return: The formatted text or the key itself if there is no associated value.
+        :rtype: str
+        """
+        ...
+
+    def get_list(
+        self,
+        key: str,
+        language: str | None = None,
+    ) -> tuple[str, ...]:
+        """Gets a list of strings associated to the specified key.
+
+        - If there is no value associated to the specified key, an empty list is returned.
+        - If there is no value associated to the specified key in the specified language,
+        the default translation is returned (or an empty list, as per the above).
+
+        :param key: The I18N key used to identify the resource.
+        :type key: str
+        :param language: An optional language for which to get the translation, defaults to None
+        :type language: str | None, optional
+        :return: The list of strings or an empty list if there is no associated value.
+        :rtype: tuple[str, ...]
+        """
+        ...

--- a/resources/i18n/default.json
+++ b/resources/i18n/default.json
@@ -1,0 +1,283 @@
+{
+    "feature_disabled_error": "I'm sorry, but this feature is disabled. Please, try again later. (｡•́︿•̀｡)",
+    "feature_quota_exhausted_error": "I'm sorry, but I've exhausted my quota for this feature due to massive user interest. Please, try again later. (｡•́︿•̀｡)",
+    "rate_limit_error": "I'm sorry, but an error occurred when I tried to communicate with the server this feature relies on. Please, try again in a few minutes. (｡•́︿•̀｡)",
+    "missing_required_argument_error": "I'm sorry, but I cannot handle your request due to a missing argument: {argname}. Please, try again by specifying the argument. (｡•́︿•̀｡)",
+    "server_not_found_error": "I'm sorry, but I couldn't find the requested server. Please, double check for any typos. (｡•́︿•̀｡)",
+    "channel_not_found_error": "I'm sorry, but I couldn't find the requested channel. Please, double check for any typos. (｡•́︿•̀｡)",
+    "user_not_found_error": "I'm sorry, but I couldn't find the requested user. Please, double check for any typos. (｡•́︿•̀｡)",
+    "missing_dm_permission_error": "I'm sorry, but I don't have the permission to DM users. Please, kindly ask your server administrator to grant me the permission. Thank you! („• ᴗ •„)",
+
+    "interactions": {
+        "halted_interaction_error": "I'm sorry, but you're not allowed to use this command. (｡•́︿•̀｡)",
+        "invalid_interaction_data_error": "I'm sorry, but this interaction isn't valid anymore. If you tried to interact with an old message, it may have expired already. If this problem persists on new interactions, please report the issue (see `/info`). Thank you! („• ᴗ •„)",
+        "invalid_interaction_error": "I'm sorry, but I couldn't execute your command, because it's invalid. (｡•́︿•̀｡)",
+        "server_only_interaction_error": "I'm sorry, but this interaction is available for servers only. (｡•́︿•̀｡)",
+        "unbound_interaction_user_error": "I'm sorry, but you're not allowed to interact with that message. (｡•́︿•̀｡)"
+    },
+
+    "extensions": {
+        "admin": {
+            "help_workflow": {
+                "explanation": "Rules are logically separated by the following types:\n- **Global rules**: These rules apply to every command, regardless of group, sub-group or name.\n- **Group rules**: These rules apply to entire command groups, such as \"admin\".\n- **Sub-group rules**: These rules apply to a specific sub-group of a specific group, such as \"commands\".\n- **Command rules**: These rules apply to specific commands, such as \"help\".\nEach one of these groups may apply to all channels or a specific channel only.\n\nThe rule precedence is as follows: _global rules > group rules > sub-group rules > command rules_. Rules that apply to all channels are applied before those that apply to specific channels only.\n\nFor example, to allow the execution of commands in a single channel only, you would need two rules:\n1. :no_entry: Forbid the execution of all commands in every channel.\n2. :white_check_mark: Allow the execution of all commands in a specific channel."
+            },
+            "remove_all_command_rules_workflow": {
+                "all_rules_removed": "I've removed all of the rules specified for this server. („• ᴗ •„)",
+                "no_rules_removed": "I haven't removed any rules. You must confirm your intention correctly."
+            },
+            "remove_command_rule_workflow": {
+                "rule_removed": "The rule has been removed."
+            },
+            "set_command_rule_workflow": {
+                "invalid_command_error": "I'm sorry, but I cannot identify the command you specified, hence the rule couldn't be set. (｡•́︿•̀｡)",
+                "rule_set_successfully": "Your rule has been set: {rule_text}",
+                "server_only_command_error": "I'm sorry, but command rules can be defined in servers only. (｡•́︿•̀｡)"
+            },
+            "test_command_workflow": {
+                "command_can_execute": "The command _can be_ executed in <#{channel_id}>.",
+                "command_cannot_execute": "The command _cannot be_ executed in <#{channel_id}>.",
+                "invalid_command_error": "I'm sorry, but I cannot identify the command you specified. Please, double check for any typos. (｡•́︿•̀｡)"
+            },
+            "view_command_rules_workflow": {
+                "embed_title": "Command rules",
+                "embed_description": "The list of command rules set on this server.",
+                "embed_name_field": "Rule #{rule_id}",
+                "no_command_rules_configured": "No command rules matching the query have been configured for the server.",
+                "subgroup_requires_group_error": "You can specify a subgroup if and only if you specify a group, too."
+            }
+        },
+
+        "general": {
+            "magic_eight_ball_workflow": {
+                "responses": [
+                    "Yes.",
+                    "But of course!",
+                    "Certainly.",
+                    "Without a doubt.",
+                    "Yes, definitely.",
+                    "Most likely.",
+                    "It seems to be the case.",
+                    "No.",
+                    "Of course, not!",
+                    "Quite unlikely.",
+                    "Don't count on it.",
+                    "I don't think so.",
+                    "Maybe.",
+                    "You don't have to know that.",
+                    "That's not your cup of tea.",
+                    "Who knows..."
+                ]
+            },
+            "roll_number_workflow": {
+                "unusual_roll_result": "I rolled an unusually shaped die for you and got {value}. („• ᴗ •„)",
+                "usual_roll_result": "I rolled a {name} for you and got {value}. („• ᴗ •„)",
+                "die_1": "Möbius strip",
+                "die_4": "tetrahedron",
+                "die_6": "cube",
+                "die_8": "octahedron",
+                "die_10": "pentagonal trapezohedron",
+                "die_12": "dodecahedron",
+                "die_20": "icosahedron",
+                "die_24": "pseudo-deltoidal icositetrahedron",
+                "die_50": "icosikaipentagonal trapezohedron",
+                "die_120": "disdyakis triacontahedron"
+            },
+            "summon_user_workflow": {
+                "self_summon": "And thus, be summoned, <@{user_id}>! („• ᴗ •„)",
+                "dm_summon_with_message": "{user_name} requests your presence at <#{channel_id}>:\n> {message}",
+                "dm_summon": "{user_name} requests your presence at <#{channel}>.",
+                "successful_summon": "I'll be back in a moment with <@{user_id}>...",
+                "cannot_summon_bot_error": "I'm sorry, but I'd rather not disturb a fellow bot. (｡•́︿•̀｡)"
+            },
+            "view_bot_info_workflow": {
+                "embed_title": "Holo's information",
+                "embed_description": "Some information about the bot.",
+                "embed_footer": "Brought to you by rexor12",
+                "general_field": "General",
+                "general_value": "Version: _{version}_\nLatency: _{latency:,.2f} ms_\nServers: _{servers}_\nTime: _{server_time:%I:%M:%S %p, %m/%d/%Y %Z}_",
+                "project_home": "Project home",
+                "bug_reports": "Bug reports"
+            },
+            "view_emoji_workflow": {
+                "emoji_not_found_error": "I'm sorry, but I couldn't find the emoji you requested. Please, double check for any typos. (｡•́︿•̀｡)",
+                "invalid_emoji_error": "I'm sorry, but the emoji you requested isn't an image asset based one, so I can't embed it. (｡•́︿•̀｡)"
+            },
+            "view_user_avatar_workflow": {
+                "embed_footer": "Artwork by {artist}",
+                "embed_title": "{user}'s avatar"
+            }
+        },
+
+        "google": {
+            "search_google_workflow": {
+                "no_results": "I couldn't find any good results for you. Please, refine your keywords and try again. („• ᴗ •„)",
+                "google_error": "I'm sorry, but a Google internal error has occurred. Please, try again a bit later; or, if the problem persists, report the issue (see `/info`). Thank you! („• ᴗ •„)"
+            }
+        },
+
+        "hentai": {
+            "link_hentai_workflow": {
+                "missing_site_or_code_error": "You must specify both the site and the identifier.",
+                "nhentai_invalid_code_error": "I'm sorry, but you specified a code that isn't valid for NHentai. It should look similar to this: _166806_. Please, double check for any typos. (｡•́︿•̀｡)",
+                "ehentai_invalid_code_error": "I'm sorry, but you specified a code that isn't valid for E-Hentai. It should look similar to this: _945882/2d77566ffe_. Please, double check for any typos. (｡•́︿•̀｡)",
+                "invalid_site_error": "I'm sorry, but you specified a site I don't know how to use. Please, double check for any typos. (｡•́︿•̀｡)"
+            }
+        },
+
+        "moderation": {
+            "permissions": {
+                "0": "none",
+                "1": "mute users",
+                "2": "kick users",
+                "4": "ban users",
+                "8": "warn users"
+            },
+            "reason_out_of_range_error": "I'm sorry, but the reason's length must be between {min} and {max} characters. Please, correct it and try again. (｡•́︿•̀｡)",
+            "warn_count_out_of_range_error": "I'm sorry, but the number of warn strikes must fall between {min} and {max}. Please, correct it and try again. (｡•́︿•̀｡)",
+            "duration_out_of_range_error": "I'm sorry, but the duration must fall between {min} and {max}. Please, correct it and try again. (｡•́︿•̀｡)",
+            "add_moderator_permission_workflow": {
+                "permission_assigned": "I've assigned <@{user_id}> the permission to {permission}."
+            },
+            "remove_moderator_permission_workflow": {
+                "permission_revoked": "I've revoked <@{user_id}>'s permission to {permission}."
+            },
+            "ban_user_workflow": {
+                "days_out_of_range_error": "I'm sorry, but the number of days must fall between {min} and {max}. Please, correct it and try again. (｡•́︿•̀｡)",
+                "cannot_ban_user_error": "I'm sorry, but I couldn't banish <@{user_id}>. Please, make sure I have the required permissions and they don't have a role ranking higher than mine. (｡•́︿•̀｡)",
+                "user_banned_dm": "{user_name} requested I banish you from {server_name}. I'm sorry to see you go. (｡•́︿•̀｡)\n> {reason}",
+                "user_banned_dm_no_reason": "{user_name} requested I banish you from {server_name}. I'm sorry to see you go. (｡•́︿•̀｡)",
+                "user_banned": "I've successfully banished <@{user_id}>.\n> {reason}",
+                "user_banned_no_reason": "I've successfully banished <@{user_id}>."
+            },
+            "clear_log_channel_workflow": {
+                "logs_disabled": "I won't publish logs about moderation command usage anymore."
+            },
+            "disable_auto_ban_workflow": {
+                "auto_ban_disabled": "I won't automatically banish users anymore."
+            },
+            "disable_auto_kick_workflow": {
+                "auto_kick_disabled": "I won't automatically kick users anymore."
+            },
+            "disable_auto_mute_workflow": {
+                "auto_mute_disabled": "I won't automatically mute users anymore."
+            },
+            "disable_warn_decay_workflow": {
+                "auto_warn_disabled": "I won't automatically remove warn strikes anymore."
+            },
+            "kick_user_workflow": {
+                "cannot_kick_user_error": "I'm sorry, but I couldn't kick <@{user_id}>. Please, make sure I have the required permissions and they don't have a role ranking higher than mine. (｡•́︿•̀｡)",
+                "user_kicked_dm": "{user_name} requested I kick you from {server_name}. I'm sorry to see you go. (｡•́︿•̀｡)\n> {reason}",
+                "user_kicked_dm_no_reason": "{user_name} requested I kick you from {server_name}. I'm sorry to see you go. (｡•́︿•̀｡)",
+                "user_kicked": "I've successfully kicked <@{user_id}>.\n> {reason}",
+                "user_kicked_no_reason": "I've successfully kicked <@{user_id}>."
+            },
+            "mute_user_workflow": {
+                "cannot_mute_user_error": "I'm sorry, but I couldn't mute <@{user_id}>. Please, make sure I have the required permissions and they don't have a role ranking higher than mine. (｡•́︿•̀｡)",
+                "user_muted_dm": "{user_name} requested I mute you in {server_name}. Please, behave yourself next time. (｡•́︿•̀｡)\n> {reason}",
+                "user_muted_dm_no_reason": "{user_name} requested I mute you in {server_name}. Please, behave yourself next time. (｡•́︿•̀｡)",
+                "user_muted": "I've successfully muted <@{user_id}>.\n> {reason}",
+                "user_muted_no_reason": "I've successfully muted <@{user_id}>."
+            },
+            "set_auto_ban_workflow": {
+                "autoban_configured": "I'll automatically banish users after {warns} warn strikes."
+            },
+            "set_auto_kick_workflow": {
+                "autokick_configured": "I'll automatically kick users after {warns} warn strikes."
+            },
+            "set_auto_mute_workflow": {
+                "automute_configured": "I'll automatically mute after {warns} warn strikes."
+            },
+            "set_log_channel_workflow": {
+                "modlog_configured": "I'll publish logs about moderation command usage in <#{channel_id}>. Please, make sure you assign me the necessary permissions so I can send messages there. („• ᴗ •„)"
+            },
+            "set_warn_decay_workflow": {
+                "decay_configured": "I'll automatically remove warn strikes that are older than {decay_time}."
+            },
+            "unmute_user_workflow": {
+                "cannot_unmute_user_error": "I'm sorry, but I couldn't unmute <@{user_id}>. Please, make sure I have the required permissions and they don't have a role ranking higher than mine. (｡•́︿•̀｡)",
+                "user_unmuted_dm": "{user_name} requested I unmute you in {server_name}. („• ᴗ •„)",
+                "user_unmuted": "I've successfully unmuted <@{user_id}>."
+            },
+            "view_warn_decay_workflow": {
+                "decay_disabled": "I don't invalidate warn strikes over time automatically.",
+                "decay_enabled": "I invalidate warn strikes after {time}."
+            },
+            "warn_user_workflow": {
+                "user_warned_dm": "{user_name} requested I warn you in {server_name}. Please, behave yourself next time. (｡•́︿•̀｡)\n> {reason}",
+                "user_warned_dm_no_reason": "{user_name} requested I warn you in {server_name}. Please, behave yourself next time. (｡•́︿•̀｡)",
+                "user_warned": "I've successfully warned <@{user_id}>.\n> {reason}",
+                "user_warned_no_reason": "I've successfully warned <@{user_id}>."
+            }
+        },
+
+        "reminders": {
+            "remove_reminder_workflow": {
+                "reminder_deleted": "I've deleted your reminder. Make sure you don't forget about it if it's important, though. („• ᴗ •„)",
+                "reminder_not_found_error": "I'm sorry, but I couldn't find this one among your reminders. Please, double check for any typos. (｡•́︿•̀｡)"
+            },
+            "set_reminder_workflow": {
+                "reminder_set": "I'll remind you at {time:%I:%M:%S %p, %m/%d/%Y} UTC.",
+                "message_out_of_range_error": "I'm sorry, but the message's length must be between {min} and {max} characters. Please, correct it and try again. (｡•́︿•̀｡)",
+                "missing_time_error": "I'm sorry, but I need to know either the frequency of the reminder or the date and time at which I should remind you. Please, double check and try again. (｡•́︿•̀｡)",
+                "invalid_params_error": "I'm sorry, but the parameters {param1} and {param2} cannot be used together. Please, double check and try again. (｡•́︿•̀｡)",
+                "too_many_reminders_error": "I'm sorry, but you've reached the maximum number of reminders you can have. Please, remove at least one and try again. (｡•́︿•̀｡)"
+            },
+            "view_reminders_workflow": {
+                "no_reminders": "You don't have any reminders.",
+                "embed_title": "Reminders",
+                "embed_description": "Embeds of <@{user_id}>.",
+                "embed_footer": "Use the reminder's number for removal.",
+                "embed_field_name": "#{reminder_id}",
+                "embed_field_value": "> Message: {message}\n> Next trigger: {time:%I:%M:%S %p, %m/%d/%Y} UTC\n> Repeats: {repeats}"
+            }
+        },
+
+        "server": {
+            "view_server_icon_workflow": {
+                "unknown_server_error": "I'm sorry, but I cannot query the server's data. Please, try again a bit later; or, if the problem persists, report the issue (see `/info`). Thank you! („• ᴗ •„)",
+                "no_server_icon": "Your server doesn't have an icon. (｡•́︿•̀｡)",
+                "embed_title": "{name}'s icon"
+            }
+        },
+
+        "todo_lists": {
+            "add_todo_item_workflow": {
+                "item_added": "I've added the item to your to-do list. Make sure you don't forget to do it! („• ᴗ •„)",
+                "message_too_long_error": "I'm sorry, but I'm afraid your message is a bit too short or long. Please, make sure the length is between {lower_bound} and {upper_bound} characters. (｡•́︿•̀｡)",
+                "list_full_error": "I'm sorry, but your to-do list is full. I think it's about time to get a few things done. („• ᴗ •„)"
+            },
+            "remove_all_todo_items_workflow": {
+                "items_deleted": "I've removed all {count} of your to-do items. Make sure you don't slack, though. („• ᴗ •„)",
+                "no_todo_items_error": "There's nothing to remove. It's time to add a to-do item and then get to work. („• ᴗ •„)"
+            },
+            "remove_todo_item_workflow": {
+                "item_deleted": "I've removed the to-do item. Make sure you don't slack, though. („• ᴗ •„)",
+                "no_todo_item_error": "I'm sorry, but I couldn't find such a to-do item in your list. Please, double check for any typos. (｡•́︿•̀｡)"
+            },
+            "view_todo_items_workflow": {
+                "no_todo_items": "You don't have any to-do items.",
+                "embed_title": "To-do list",
+                "embed_description": "To-do items of <@{user_id}>.",
+                "embed_footer": "Use the to-do item's number for removal.",
+                "embed_field": "#{item_id}"
+            }
+        },
+
+        "weather": {
+            "get_basic_weather_workflow": {
+                "no_information_error": "I'm sorry, but OpenWeather couldn't provide any information right now. Please, try again a bit later. (｡•́︿•̀｡)",
+                "invalid_location_error": "I'm sorry, but I cannot find the location you requested. Please, double check for any typos or try a larger town nearby. (｡•́︿•̀｡)",
+                "openweather_error": "I'm sorry, but an OpenWeather internal error has occurred (code: {code}). Please, try again a bit later; or, if the problem persists, report the issue (see `/info`). Thank you! („• ᴗ •„)",
+                "embed_title": "Weather report",
+                "embed_description": "Information about the current weather in {location}.",
+                "embed_footer": "Powered by OpenWeather",
+                "embed_field_temperature": "Temperature",
+                "embed_field_temperature_value": "{temperature} °C",
+                "embed_field_pressure": "Pressure",
+                "embed_field_pressure_value": "{pressure} hPa",
+                "embed_field_humidity": "Humidity",
+                "embed_field_humidity_value": "{humidity}%"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #144.

In addition to the ne I18N provider, this implements/changes the following:
* ability for the developer to specify for an action whether mentions should be suppressed (ie. Discord doesn't ping the user)
* modidfy the majority of bot messages to be less technical and more user-friendly
* remove duplicated messages (eg. user not found)

The usage is as follows:
* there can exist one and only one i18n.json file in the i18n directory, which serves as the default language
* if no language is specified _or_ the language has no i18n _or_ the key isn't found in the language-specific file, then the provider falls back to the default language
* if the key cannot be found in either the language specific and default language file, the key itself is returned
* a language specific file must be named as `i18n_language.json`, for example `i18n_english.json` or `i18n_en-US.json`