### PR TITLE
Fix bug, improve readability

### DIFF
--- a/holobot/sdk/utils/dict_utils.py
+++ b/holobot/sdk/utils/dict_utils.py
@@ -10,7 +10,7 @@ def get_or_add(
     value_factory: Callable[[TState], TValue],
     state: TState
 ) -> TValue:
-    existing_value = dictionary.get(key, None)
-    if not existing_value:
-        dictionary[key] = existing_value = value_factory(state)
-    return existing_value
+    if key in dictionary:
+        return dictionary[key]
+    dictionary[key] = value_factory(state)
+    return dictionary[key]


### PR DESCRIPTION
Fixes a bug where dict entry `{key: None}.get(key)` is treated as missing, and value is wrongly created using factory.
Also rewrote this function in a more concise manner, since there is no statistically significant performance difference.