### PR TITLE
Fix datetimes to use the correct timezone info

### DIFF
--- a/holobot/extensions/reminders/models/reminder.py
+++ b/holobot/extensions/reminders/models/reminder.py
@@ -31,7 +31,7 @@ class Reminder:
     def recalculate_next_trigger(self) -> None:
         if not self.is_repeating:
             raise ValueError("A non-recurring reminder cannot have a new trigger date-time.")
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         repeat_count = int((current_time - self.base_trigger) / self.frequency_time)
         trigger_time = self.base_trigger + (repeat_count + 1) * self.frequency_time
         if trigger_time > self.last_trigger + self.frequency_time:

--- a/holobot/extensions/reminders/reminder_manager.py
+++ b/holobot/extensions/reminders/reminder_manager.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from holobot.sdk.configs import ConfiguratorInterface
 from holobot.sdk.exceptions import ArgumentError, ArgumentOutOfRangeError
@@ -41,7 +41,7 @@ class ReminderManager(ReminderManagerInterface):
         if config.every_interval is not None:
             reminder = await self.__set_recurring_reminder(user_id, config.message, config.every_interval, config.at_time)
         elif config.in_time is not None:
-            next_trigger = datetime.utcnow() + config.in_time
+            next_trigger = datetime.now(timezone.utc) + config.in_time
             reminder = await self.__set_single_reminder(user_id, config.message, next_trigger)
         elif config.at_time is not None:
             next_trigger = self.__calculate_single_trigger_at(config.at_time)
@@ -95,7 +95,7 @@ class ReminderManager(ReminderManagerInterface):
         return reminder
 
     def __calculate_recurring_base_trigger(self, frequency_time: timedelta, at_time: timedelta | None):
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         if at_time is None:
             return current_time
 
@@ -105,6 +105,6 @@ class ReminderManager(ReminderManagerInterface):
     def __calculate_single_trigger_at(self, at_time: timedelta) -> datetime:
         # TODO Make this aware of the user's locale. We can't expect random people to deal with UTC.
         # https://discordpy.readthedocs.io/en/stable/api.html#discord.ClientUser.locale
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         trigger_time = datetime(current_time.year, current_time.month, current_time.day) + at_time
         return trigger_time + timedelta(1) if trigger_time < current_time else trigger_time

--- a/holobot/extensions/reminders/reminder_processor.py
+++ b/holobot/extensions/reminders/reminder_processor.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Awaitable
-from datetime import datetime
+from datetime import datetime, timezone
 
 from holobot.discord.sdk import IMessaging
 from holobot.sdk.configs import ConfiguratorInterface
@@ -66,7 +66,7 @@ class ReminderProcessor(IStartable):
                     await self.__messaging.send_private_message(reminder.user_id, f"Your reminder: {reminder.message}")
 
                     if reminder.is_repeating:
-                        reminder.last_trigger = datetime.utcnow()
+                        reminder.last_trigger = datetime.now(timezone.utc)
                         reminder.recalculate_next_trigger()
                         await self.__reminder_repository.update(reminder)
                         self.__logger.trace(


### PR DESCRIPTION
```py
from datetime import datetime, timezone

# returns None
print(f"First: {datetime.utcnow().tzinfo}")

# returns UTC
print(f"Second: {datetime.now(timezone.utc).tzinfo}")
```

Closes #194 