### PR TITLE
Consider context data in cooldown entity IDs

### DIFF
--- a/holobot/discord/workflows/events/interactable_processed_event_listener.py
+++ b/holobot/discord/workflows/events/interactable_processed_event_listener.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from holobot.discord.sdk.events import (
     CommandProcessedEvent, ComponentProcessedEvent, MenuItemProcessedEvent
 )
-from holobot.discord.sdk.workflows.interactables.enums import EntityType
 from holobot.discord.workflows import IInvocationTracker
+from holobot.discord.workflows.utils import get_entity_id
 from holobot.sdk.ioc.decorators import injectable
 from holobot.sdk.reactive import IListener
 
@@ -26,8 +26,12 @@ class InteractableProcessedEventListener(IListener[_EVENT_TYPE]):
         if not cooldown:
             return
 
-        entity_id = InteractableProcessedEventListener.__get_entity_id(event, cooldown.entity_type)
-        if not entity_id:
+        if not (entity_id := get_entity_id(
+            event.interactable,
+            event.server_id,
+            event.channel_id,
+            event.user_id
+        )):
             return
 
         await self.__invocation_tracker.set_invocation(
@@ -35,13 +39,3 @@ class InteractableProcessedEventListener(IListener[_EVENT_TYPE]):
             entity_id,
             datetime.now(timezone.utc)
         )
-
-    @staticmethod
-    def __get_entity_id(
-        event: _EVENT_TYPE,
-        entity_type: EntityType
-    ) -> str | None:
-        if entity_type == EntityType.USER:
-            return event.user_id
-
-        return event.channel_id if entity_type == EntityType.CHANNEL else event.server_id

--- a/holobot/discord/workflows/invocation_tracker.py
+++ b/holobot/discord/workflows/invocation_tracker.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from holobot.discord.sdk.workflows.interactables.enums import EntityType
 from holobot.sdk.caching import ConcurrentCache
 from holobot.sdk.ioc.decorators import injectable
-from holobot.sdk.utils import UndefinedType
 from .iinvocation_tracker import IInvocationTracker
 
 @injectable(IInvocationTracker)

--- a/holobot/discord/workflows/rules/is_interactable_on_cooldown_rule.py
+++ b/holobot/discord/workflows/rules/is_interactable_on_cooldown_rule.py
@@ -63,10 +63,10 @@ class IsInteractableOnCooldownRule(IWorkflowExecutionRule):
         interactable: Interactable,
         context: InteractionContext
     ) -> str | None:
-        server_id = None
-        channel_id = None
-        if isinstance(context, _SERVER_CONTEXTS):
-            server_id = context.server_id
-            channel_id = context.channel_id
+        server_id, channel_id = (
+            (context.server_id, context.channel_id)
+            if isinstance(context, _SERVER_CONTEXTS)
+            else (None, None)
+        )
 
         return get_entity_id(interactable, server_id, channel_id, context.author_id)

--- a/holobot/discord/workflows/utils/__init__.py
+++ b/holobot/discord/workflows/utils/__init__.py
@@ -1,0 +1,1 @@
+from .invocation_utils import get_entity_id

--- a/holobot/discord/workflows/utils/invocation_utils.py
+++ b/holobot/discord/workflows/utils/invocation_utils.py
@@ -1,0 +1,35 @@
+from holobot.discord.sdk.workflows.interactables import Command, Component, Interactable, MenuItem
+from holobot.discord.sdk.workflows.interactables.enums import EntityType
+
+def get_entity_id(
+    interactable: Interactable,
+    server_id: str | None,
+    channel_id: str | None,
+    user_id: str
+) -> str | None:
+    if not interactable.cooldown:
+        return None
+
+    entity_type = interactable.cooldown.entity_type
+    id_parts = []
+    # The server ID is always included (when available) to avoid cross-server cooldowns.
+    if server_id:
+        id_parts.append(("server", server_id))
+    if entity_type is EntityType.CHANNEL and channel_id:
+        id_parts.append(("channel", channel_id))
+    elif entity_type is EntityType.USER:
+        id_parts.append(("user", user_id))
+
+    # Unknown interactable types share a common cooldown, otherwise it's specific.
+    match interactable:
+        case Command() as command:
+            id_parts.append((
+                "command",
+                ".".join((command.group_name or "", command.subgroup_name or "", command.name))
+            ))
+        case Component() as component:
+            id_parts.append(("component", component.identifier))
+        case MenuItem() as menu_item:
+            id_parts.append(("menu", menu_item.title))
+
+    return "/".join(map(lambda i: ":".join(i), id_parts))

--- a/holobot/discord/workflows/utils/invocation_utils.py
+++ b/holobot/discord/workflows/utils/invocation_utils.py
@@ -15,10 +15,10 @@ def get_entity_id(
     # The server ID is always included (when available) to avoid cross-server cooldowns.
     if server_id:
         id_parts.append(("server", server_id))
-    if entity_type is EntityType.CHANNEL and channel_id:
-        id_parts.append(("channel", channel_id))
-    elif entity_type is EntityType.USER:
-        id_parts.append(("user", user_id))
+
+    match entity_type:
+        case EntityType.CHANNEL if channel_id: id_parts.append(("channel", channel_id))
+        case EntityType.USER: id_parts.append(("user", user_id))
 
     # Unknown interactable types share a common cooldown, otherwise it's specific.
     match interactable:


### PR DESCRIPTION
Cooldown tracking entity IDs will now correctly separate cooldowns for different commands. The IDs will contain parts of the following information - depending on the tracking settings -, in a consistent order:
* server ID
* channel ID
* user ID
* interactable ID

Examples:
* server-wide cooldown for a command
  * server:123123123/command:admin.commands.viewrules
* channel-wide cooldown for a component
  * Invoked in a server: server:123123123/channel:123123123/component:rulepagerbackbtn
  * Invoked in DM: channel:123123123/component:rulepagerbackbtn
* user-specific cooldown for a menu item
  * Invoked in a server: server:123123123/user:123123123/menu:View user info
  * Invoked in DM: user:123123123/menu:View user info

When available, the server ID is always part of the entity ID so that interactables aren't locked globally. May the need arise for such a scenario, the implementation can be extended later (eg. by a boolean flag for the Cooldown object).

Closes #197 