### PR TITLE
Fix /match scoring

### DIFF
--- a/config.json
+++ b/config.json
@@ -250,7 +250,7 @@
             "ProgressBarRedEmoji": "<:barr2:1053832599807725638>",
             "ProgressBarOrangeEmoji": "<:baro2:1053832598494908456>",
             "ProgressBarGreenEmoji": "<:barg2:1053832597173719100>",
-            "RefreshRelationshipsAfterMinutes": 30
+            "RefreshRelationshipsAfterMinutes": 10
         },
         "WaifuPicsOptions": {
             "CircuitBreakerFailureThreshold": 1,

--- a/resources/i18n/default.json
+++ b/resources/i18n/default.json
@@ -108,10 +108,10 @@
                 "commitment": "Commitment",
                 "security": "Security",
                 "type": "Type of love",
-                "overall_score": "Overall score",
+                "overall_score": "Overall score (1-10)",
                 "overall_score_value": "{score}/10 {emoji}",
                 "overall_score_emojis": [
-                    "💔", "👩‍❤️‍💋‍👨", "💓", "🤼", "❤️", "💙"
+                    "💔", "👩‍❤️‍💋‍👨", "💓", "🤼", "❤️", "💙", "🤍"
                 ],
                 "footer": "Data will refresh in {refresh_in} minute(s)."
             },


### PR DESCRIPTION
Closes #262 

* Scores will now be from 1 to 10
* Instead of calculating the score from the generated bars the opposite is done: the score is generated first then matching bars are generated for it based on pre-defined median values for each love type
* Reaching score 10 gives the user a ~1/1000 chance to end up with a full score (all bars 100%) which uses a special white heart emoji